### PR TITLE
feat: S3 연동 및 파일 업로드 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'software.amazon.awssdk:s3:2.25.20'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/backend/src/main/java/com/overlang/api/controller/AuthController.java
+++ b/backend/src/main/java/com/overlang/api/controller/AuthController.java
@@ -53,10 +53,4 @@ public class AuthController {
         new AuthMeResponse(
             member.getId(), member.getFirebaseUid(), member.getEmail(), member.getName()));
   }
-
-  // DTO 레코드
-  public record AuthFirebaseResponse(
-      Long memberId, String firebaseUid, String email, boolean isNewMember) {}
-
-  public record AuthMeResponse(Long memberId, String firebaseUid, String email, String name) {}
 }

--- a/backend/src/main/java/com/overlang/api/controller/FileController.java
+++ b/backend/src/main/java/com/overlang/api/controller/FileController.java
@@ -1,4 +1,22 @@
 package com.overlang.api.controller;
 
+import com.overlang.api.dto.file.FileUploadResponse;
+import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/files")
 public class FileController {
+
+  private final S3UploadService s3UploadService;
+
+  @PostMapping(value = "/upload", consumes = "multipart/form-data")
+  public ApiResponse<FileUploadResponse> upload(@RequestPart("file") MultipartFile file) {
+    FileUploadResponse response = s3UploadService.uploadVideo(file);
+    return ApiResponse.success(response);
+  }
 }

--- a/backend/src/main/java/com/overlang/api/controller/FileController.java
+++ b/backend/src/main/java/com/overlang/api/controller/FileController.java
@@ -1,0 +1,4 @@
+package com.overlang.api.controller;
+
+public class FileController {
+}

--- a/backend/src/main/java/com/overlang/api/dto/file/FileUploadResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/file/FileUploadResponse.java
@@ -1,4 +1,3 @@
 package com.overlang.api.dto.file;
 
-public class FileUploadResponse {
-}
+public record FileUploadResponse(String fileName, String s3Key, String fileUrl) {}

--- a/backend/src/main/java/com/overlang/api/dto/file/FileUploadResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/file/FileUploadResponse.java
@@ -1,0 +1,4 @@
+package com.overlang.api.dto.file;
+
+public class FileUploadResponse {
+}

--- a/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
+++ b/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
@@ -1,4 +1,80 @@
 package com.overlang.domain.file.service;
 
+import com.overlang.api.dto.file.FileUploadResponse;
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
 public class S3UploadService {
+
+  private static final Set<String> ALLOWED_CONTENT_TYPES =
+      Set.of("video/mp4", "video/quicktime", "video/x-msvideo", "video/x-matroska");
+
+  private final S3Client s3Client;
+  private final String bucket;
+  private final String region;
+
+  public S3UploadService(
+      S3Client s3Client,
+      @Value("${cloud.aws.s3.bucket}") String bucket,
+      @Value("${cloud.aws.region.static}") String region) {
+    this.s3Client = s3Client;
+    this.bucket = bucket;
+    this.region = region;
+  }
+
+  public FileUploadResponse uploadVideo(MultipartFile file) {
+    validateFile(file);
+
+    String originalFilename = file.getOriginalFilename();
+    String extension = extractExtension(originalFilename);
+    String uniqueFileName = UUID.randomUUID() + extension;
+    String s3Key = "uploads/videos/" + uniqueFileName;
+
+    try {
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(s3Key)
+              .contentType(file.getContentType())
+              .build();
+
+      s3Client.putObject(
+          putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+      String fileUrl = buildFileUrl(s3Key);
+
+      return new FileUploadResponse(originalFilename, s3Key, fileUrl);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("파일 업로드 중 오류가 발생했습니다.");
+    }
+  }
+
+  private void validateFile(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+    }
+
+    if (file.getContentType() == null || !ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+      throw new IllegalArgumentException("지원하지 않는 영상 형식입니다.");
+    }
+  }
+
+  private String extractExtension(String fileName) {
+    if (fileName == null || !fileName.contains(".")) {
+      return "";
+    }
+    return fileName.substring(fileName.lastIndexOf("."));
+  }
+
+  private String buildFileUrl(String s3Key) {
+    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3Key;
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
+++ b/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.file.service;
+
+public class S3UploadService {
+}

--- a/backend/src/main/java/com/overlang/global/config/S3Config.java
+++ b/backend/src/main/java/com/overlang/global/config/S3Config.java
@@ -1,4 +1,32 @@
 package com.overlang.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
 public class S3Config {
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public S3Client s3Client() {
+    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .build();
+  }
 }

--- a/backend/src/main/java/com/overlang/global/config/S3Config.java
+++ b/backend/src/main/java/com/overlang/global/config/S3Config.java
@@ -1,0 +1,4 @@
+package com.overlang.global.config;
+
+public class S3Config {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,3 +17,12 @@ spring.jpa.open-in-view=false
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+# S3 \uC124\uC815
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
+cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=overlang-dev-files-gukhee
+
+spring.servlet.multipart.max-file-size=2GB
+spring.servlet.multipart.max-request-size=2GB


### PR DESCRIPTION
## 작업 개요
영상 파일 업로드를 위한 AWS S3 연동 및 파일 업로드 API 구현

## 관련 이슈
- close #32 

## 작업 내용
- AWS S3 버킷 연동 설정
- S3Config 설정 클래스 추가
- S3UploadService 구현 (파일 업로드 로직)
- FileController에 `/api/v1/files/upload` API 추가
- 파일 업로드 시 S3에 저장 후 fileUrl 반환하도록 구현

## 체크리스트 (DoD)
- [X] 빌드 및 테스트 통과 확인
- [X] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [X] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="2376" height="865" alt="image" src="https://github.com/user-attachments/assets/94f02cb3-2952-4fc8-bbe8-be79b4a48b41" />
<img width="2337" height="733" alt="image" src="https://github.com/user-attachments/assets/f369b361-af03-458c-ac34-3bc5fae4cc96" />
<img width="1821" height="771" alt="image" src="https://github.com/user-attachments/assets/b310cc44-24f3-406a-997c-0de510a778e8" />


## 기타 사항
- 현재 DB에는 fileUrl 저장 로직은 미구현 상태 (Project API에서 연동 예정)