### PR TITLE
feat: AnalysisRequest, Worker payload, JobStatus 스키마 정리

### DIFF
--- a/ai/api/routes.py
+++ b/ai/api/routes.py
@@ -1,78 +1,97 @@
-from fastapi import APIRouter
-from ai.api.schemas import AnalysisRequest, AnalysisResponse, TaskStatusResponse
-from ai.worker.celery_app import celery_app
+import json
+
 from celery.result import AsyncResult
+from fastapi import APIRouter
+
+from ai.api.schemas import (
+    AnalysisRequest,
+    AnalysisResponse,
+    CurrentStage,
+    ErrorCode,
+    JobStatus,
+    TaskStatusResponse,
+)
+from ai.worker.celery_app import celery_app
 
 router = APIRouter()
 
 
 @router.post("/analyze", response_model=AnalysisResponse)
 async def analyze_audio(request: AnalysisRequest):
-    """
-    오디오 분석 작업을 요청.
-    Celery Worker에게 작업을 비동기로 전달하고, 작업 ID(Job ID)를 즉시 반환.
+    options = dict(request.options or {})
+    if request.source_language:
+        options["language"] = request.source_language
 
-    Args:
-        request.file_path: 분석할 오디오 파일 경로 (Docker 내부 경로)
-        request.options: 분석 옵션 (모델명, 언어, 배치 사이즈 등)
-
-    Returns:
-        jobId: 작업 추적 ID
-        status: PENDING (작업 대기 중)
-    """
-    # Celery 작업 큐에 작업 추가 (비동기)
-    # send_task를 사용하여 Worker 코드와의 의존성을 분리.
     task = celery_app.send_task(
-        "ai.worker.tasks.process_audio_task", args=[request.file_path, request.options]
+        "ai.worker.tasks.process_audio_task",
+        args=[request.resolve_local_input_path(), options],
     )
 
     return AnalysisResponse(
-        job_id=task.id, status="PENDING", message="Task submitted successfully"
+        job_id=task.id,
+        status=JobStatus.PENDING,
+        message="Task submitted successfully",
     )
 
 
 @router.get("/status/{job_id}", response_model=TaskStatusResponse)
 async def get_task_status(job_id: str):
-    """
-    특정 작업(Job ID)의 현재 상태와 결과를 조회.
-
-    Returns:
-        status: PENDING, PROCESSING, SUCCESS, FAILURE 중 하나
-        progress: 진행률 (0.0 ~ 100.0)
-        result: 완료된 경우 분석 결과 데이터
-        errorCode: 실패 시 에러 코드
-        errorMessage: 실패 시 에러 메시지
-    """
     task_result = AsyncResult(job_id)
+    task_info = task_result.info if isinstance(task_result.info, dict) else {}
 
     response = TaskStatusResponse(
-        job_id=job_id, status=task_result.status, progress=0.0
+        job_id=job_id,
+        status=JobStatus.PENDING,
+        progress=float(task_info.get("progress", 0.0)),
+        current_stage=parse_current_stage(task_info.get("current_stage")),
     )
 
-    if task_result.state == "PENDING":
-        response.status = "PENDING"
-    elif task_result.state == "PROCESSING":
-        response.status = "PROCESSING"
-        if isinstance(task_result.info, dict):
-            response.progress = float(task_result.info.get("progress", 0))
-    elif task_result.state == "SUCCESS":
-        response.status = "SUCCESS"
+    if task_result.state == JobStatus.PENDING.value:
+        response.status = JobStatus.PENDING
+        response.current_stage = CurrentStage.QUEUED
+        return response
+
+    if task_result.state == JobStatus.RUNNING.value:
+        response.status = JobStatus.RUNNING
+        return response
+
+    if task_result.state == JobStatus.COMPLETED.value:
+        response.status = JobStatus.COMPLETED
         response.progress = 100.0
+        response.current_stage = (
+            parse_current_stage(task_info.get("current_stage"))
+            or CurrentStage.FINALIZING
+        )
         response.result = task_result.result
-    elif task_result.state == "FAILURE":
-        response.status = "FAILURE"
-        # Worker에서 발생한 에러 정보를 파싱.
+        return response
+
+    if task_result.state in {JobStatus.FAILED.value, "FAILURE"}:
+        response.status = JobStatus.FAILED
+        response.current_stage = (
+            parse_current_stage(task_info.get("current_stage"))
+            or CurrentStage.FINALIZING
+        )
+        response.progress = float(task_info.get("progress", 0.0))
+
         error_str = str(task_result.info)
         try:
-            # Worker가 JSON 형태로 에러를 던졌다면 파싱해서 구조화된 정보를 반환.
-            import json
-
             error_data = json.loads(error_str)
             response.error_code = error_data.get("code")
             response.error_message = error_data.get("message")
         except (json.JSONDecodeError, TypeError):
-            # 일반 파이썬 예외인 경우 그대로 반환
-            response.error_code = "WORKER_999"  # UNKNOWN
+            response.error_code = ErrorCode.UNKNOWN_ERROR
             response.error_message = error_str
 
+        return response
+
     return response
+
+
+def parse_current_stage(value: str | None) -> CurrentStage | None:
+    if not value:
+        return None
+
+    try:
+        return CurrentStage(value)
+    except ValueError:
+        return None

--- a/ai/api/schemas.py
+++ b/ai/api/schemas.py
@@ -1,56 +1,214 @@
-from pydantic import BaseModel, ConfigDict
-from typing import Optional, Any
+from __future__ import annotations
+
 from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SourceType(str, Enum):
+    UPLOAD = "UPLOAD"
+    YOUTUBE = "YOUTUBE"
+
+
+class JobType(str, Enum):
+    FULL_ANALYSIS = "FULL_ANALYSIS"
+    STT_ONLY = "STT_ONLY"
+    OCR_ONLY = "OCR_ONLY"
+    TRANSLATION_ONLY = "TRANSLATION_ONLY"
+    RETRY = "RETRY"
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class CurrentStage(str, Enum):
+    QUEUED = "QUEUED"
+    AUDIO_EXTRACTION = "AUDIO_EXTRACTION"
+    STT_TRANSCRIPTION = "STT_TRANSCRIPTION"
+    WHISPER_ALIGNMENT = "WHISPER_ALIGNMENT"
+    OCR_FRAME_EXTRACTION = "OCR_FRAME_EXTRACTION"
+    OCR_TEXT_DETECTION = "OCR_TEXT_DETECTION"
+    TRANSLATION = "TRANSLATION"
+    LLM_ANALYSIS = "LLM_ANALYSIS"
+    MERGING_RESULTS = "MERGING_RESULTS"
+    FINALIZING = "FINALIZING"
+
+
+class TranslationProvider(str, Enum):
+    DEFAULT = "DEFAULT"
+    DEEPL = "DEEPL"
+    OPENAI = "OPENAI"
 
 
 class ErrorCode(str, Enum):
-    """
-    Worker에서 발생할 수 있는 에러 코드 정의.
-    FE는 이 코드를 기반으로 사용자에게 적절한 안내 메시지를 표시해야 함.
-    """
-
-    GPU_OOM = "WORKER_001"  # GPU 메모리 부족
-    FILE_NOT_SUPPORTED = "WORKER_002"  # 지원하지 않는 파일 또는 파일 없음
-    UNKNOWN_ERROR = "WORKER_999"  # 알 수 없는 에러
+    GPU_OOM = "WORKER_001"
+    FFMPEG_ERROR = "WORKER_002"
+    LLM_TOKEN_EXCEEDED = "WORKER_003"
+    OCR_ENGINE_FAILED = "WORKER_004"
+    MODEL_LOAD_FAILED = "WORKER_005"
+    VIDEO_TOO_LONG = "WORKER_006"
+    INVALID_OPTIONS = "WORKER_007"
+    AUTH_FAILED = "WORKER_008"
+    TIMEOUT = "WORKER_009"
+    DOWNLOAD_FAILED = "WORKER_010"
+    UNKNOWN_ERROR = "WORKER_999"
 
 
 class CamelModel(BaseModel):
-    """
-    기본 Pydantic 설정을 담은 베이스 모델.
-    JSON 변환 시 snake_case를 CamelCase로 자동 변환.
-    """
-
     model_config = ConfigDict(
         populate_by_name=True,
-        alias_generator=lambda s: "".join(
-            word.capitalize() if i > 0 else word for i, word in enumerate(s.split("_"))
+        alias_generator=lambda value: "".join(
+            word.capitalize() if index > 0 else word
+            for index, word in enumerate(value.split("_"))
         ),
+        use_enum_values=True,
     )
 
 
 class AnalysisRequest(CamelModel):
-    """분석 요청 메타데이터"""
+    source_type: SourceType
+    file_url: str | None = None
+    source_url: str | None = None
+    job_type: JobType = JobType.FULL_ANALYSIS
+    source_language: str | None = None
+    target_language: str | None = None
+    translation_provider: TranslationProvider = TranslationProvider.DEFAULT
+    use_user_api_key: bool = False
+    options: dict[str, Any] | None = None
 
-    file_path: str  # 분석할 오디오 파일의 절대 경로
-    options: Optional[dict] = (
-        None  # 추가 분석 옵션 (예: {"no_align": true, "language": "ko"})
-    )
+    @model_validator(mode="after")
+    def validate_source_fields(self) -> "AnalysisRequest":
+        if self.source_type == SourceType.UPLOAD and not self.file_url:
+            raise ValueError("fileUrl is required when sourceType is UPLOAD")
+
+        if self.source_type == SourceType.YOUTUBE and not self.source_url:
+            raise ValueError("sourceUrl is required when sourceType is YOUTUBE")
+
+        return self
+
+    def resolve_local_input_path(self) -> str:
+        if self.source_type != SourceType.UPLOAD or not self.file_url:
+            raise ValueError(
+                "The current analyze API only supports local fileUrl uploads"
+            )
+
+        if self.file_url.startswith("file://"):
+            return self.file_url.removeprefix("file://")
+
+        return self.file_url
+
+
+class WorkerJobPayload(CamelModel):
+    job_id: int | str
+    project_id: int | str
+    source_type: SourceType
+    source_url: str | None = None
+    file_key: str | None = None
+    presigned_url: str | None = None
+    job_type: JobType = JobType.FULL_ANALYSIS
+    source_language: str | None = None
+    target_language: str | None = None
+    translation_provider: TranslationProvider = TranslationProvider.DEFAULT
+    use_user_api_key: bool = False
+
+    @model_validator(mode="after")
+    def validate_worker_payload(self) -> "WorkerJobPayload":
+        if self.source_type == SourceType.UPLOAD and not self.presigned_url:
+            raise ValueError("presignedUrl is required when sourceType is UPLOAD")
+
+        if self.source_type == SourceType.YOUTUBE and not self.source_url:
+            raise ValueError("sourceUrl is required when sourceType is YOUTUBE")
+
+        return self
+
+
+class WordTiming(CamelModel):
+    word: str
+    start_time: float | None = None
+    end_time: float | None = None
+    confidence: float | None = None
+
+
+class SubtitleSegment(CamelModel):
+    seq: int
+    start_time: float
+    end_time: float
+    text: str
+    translated_text: str | None = None
+    language_code: str | None = None
+    words: list[WordTiming] = Field(default_factory=list)
+
+
+class BoundingBox(CamelModel):
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class OcrItem(CamelModel):
+    start_time: float
+    end_time: float
+    origin_text: str
+    translated_text: str | None = None
+    bounding_box: BoundingBox
+    confidence: float | None = None
+
+
+class LearningData(CamelModel):
+    keywords: list[str] = Field(default_factory=list)
+    summary: str | None = None
+    expression_notes: list[str] = Field(default_factory=list)
+
+
+class AnalysisMetadata(CamelModel):
+    job_id: int | str
+    source_type: SourceType
+    source_language: str | None = None
+    target_language: str | None = None
+    duration: float | None = None
+    video_width: int | None = None
+    video_height: int | None = None
+    pipeline: list[str] = Field(default_factory=list)
+    fallback_used: bool = False
+
+
+class AnalysisResult(CamelModel):
+    subtitles: list[SubtitleSegment] = Field(default_factory=list)
+    ocr_items: list[OcrItem] = Field(default_factory=list)
+    learning_data: LearningData | None = None
+    metadata: AnalysisMetadata | None = None
+    warnings: list[str] = Field(default_factory=list)
 
 
 class AnalysisResponse(CamelModel):
-    """작업 생성 응답"""
-
-    job_id: str  # 생성된 작업 ID (GUID)
-    status: str  # 초기 상태 (PENDING)
-    message: str  # 응답 메시지
+    job_id: str
+    status: JobStatus
+    message: str
 
 
 class TaskStatusResponse(CamelModel):
-    """작업 상태 조회 응답"""
-
     job_id: str
-    status: str  # PENDING, PROCESSING, SUCCESS, FAILURE
-    progress: float  # 0.0 ~ 100.0
-    result: Optional[Any] = None  # 성공 시 결과 데이터
-    error_code: Optional[ErrorCode] = None  # 실패 시 에러 코드
-    error_message: Optional[str] = None  # 실패 시 상세 메시지
+    status: JobStatus
+    progress: float
+    current_stage: CurrentStage | None = None
+    result: AnalysisResult | dict[str, Any] | list[dict[str, Any]] | None = None
+    error_code: ErrorCode | str | None = None
+    error_message: str | None = None
+
+
+class CallbackPayload(CamelModel):
+    job_id: int | str
+    status: JobStatus
+    progress: float
+    current_stage: CurrentStage
+    segments: list[SubtitleSegment] = Field(default_factory=list)
+    ocr_items: list[OcrItem] = Field(default_factory=list)
+    learning_data: LearningData | None = None
+    error_code: ErrorCode | str | None = None
+    error_message: str | None = None

--- a/ai/worker/tasks.py
+++ b/ai/worker/tasks.py
@@ -1,111 +1,117 @@
-from ai.worker.celery_app import celery_app
-from ai.stt_service import STTService
-import logging
-import warnings
 import json
+import logging
 import os
+import warnings
+
 import torch
-from ai.api.schemas import ErrorCode
+
+from ai.api.schemas import CurrentStage, ErrorCode, JobStatus
+from ai.stt_service import STTService
+from ai.worker.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
 
-# UserWarning 경고 무시 (WhisperX 내부 경고 등)
 warnings.filterwarnings("ignore", category=UserWarning)
 
-# 전역 변수로 STT 서비스 인스턴스를 유지
-# Worker 프로세스가 시작될 때 한 번만 초기화되며, 이후 요청에서는 재사용
 current_stt_service = STTService(model_name="large-v3-turbo")
 
 
+def _build_task_meta(
+    progress: float,
+    current_stage: CurrentStage,
+    error_code: ErrorCode | None = None,
+    error_message: str | None = None,
+) -> dict[str, object]:
+    return {
+        "progress": float(progress),
+        "current_stage": current_stage.value,
+        "error_code": error_code.value if isinstance(error_code, ErrorCode) else error_code,
+        "error_message": error_message,
+    }
+
+
 @celery_app.task(bind=True)
-def process_audio_task(self, file_path: str, options: dict = None):
-    """
-    비동기 음성 인식 작업 (Celery Task)
-
-    Args:
-        self: Task 인스턴스 (상태 업데이트용)
-        file_path (str): 분석할 오디오 파일의 절대 경로 (/app/ai/...)
-        options (dict): 분석 옵션 (model, batch_size, language, no_align 등)
-
-    Returns:
-        dict: 분석 결과 (Segments 리스트)
-    """
+def process_audio_task(self, file_path: str, options: dict | None = None):
     global current_stt_service
 
     try:
-        logger.info(f"Task started: {file_path}")
-        # 상태 업데이트: 0%
-        self.update_state(state="PROCESSING", meta={"progress": 0})
+        logger.info("Task started: %s", file_path)
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(0, CurrentStage.QUEUED),
+        )
 
-        if options is None:
-            options = {}
-
-        # 1. 옵션 파싱 - 요청된 모델 확인 (기본값은 현재 로드된 모델 사용)
+        options = options or {}
         target_model = options.get("model", current_stt_service.model_name)
         batch_size = options.get("batch_size", 16)
         no_align = options.get("no_align", False)
         language = options.get("language", "ko")
 
-        # 2. 모델 교체 로직 (VRAM 보호 및 최적화)
-        # 요청된 모델이 현재 로드된 모델과 다르면 교체 작업을 수행
         if current_stt_service.model_name != target_model:
             logger.info(
-                f"Switching Model: {current_stt_service.model_name} -> {target_model}"
+                "Switching model: %s -> %s",
+                current_stt_service.model_name,
+                target_model,
             )
-
-            # 기존 모델 메모리 해제 (VRAM 확보)
             current_stt_service.unload_model()
-
-            # 새 모델로 인스턴스화 및 로드
             current_stt_service = STTService(model_name=target_model)
             current_stt_service.load_model()
 
-        self.update_state(state="PROCESSING", meta={"progress": 20})
-
-        # 3. 분석 실행
-        logger.info(f"Calling transcribe... Model: {target_model}, Lang: {language}")
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(20, CurrentStage.STT_TRANSCRIPTION),
+        )
 
         result = current_stt_service.transcribe(
             audio_path=file_path,
             batch_size=batch_size,
-            align=not no_align,  # no_align이 True면 align은 False
+            align=not no_align,
             language=language,
         )
 
-        logger.info("Transcribe completed.")
-        self.update_state(state="PROCESSING", meta={"progress": 90})
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(90, CurrentStage.FINALIZING),
+        )
 
-        # 4. 결과 파일 저장 - 원본 파일명 뒤에 _result.json을 붙여서 저장
         output_json_path = f"{os.path.splitext(file_path)[0]}_result.json"
-        with open(output_json_path, "w", encoding="utf-8") as f:
-            json.dump(result, f, ensure_ascii=False, indent=2)
+        with open(output_json_path, "w", encoding="utf-8") as file:
+            json.dump(result, file, ensure_ascii=False, indent=2)
 
-        logger.info(f"Result saved to: {output_json_path}")
+        logger.info("Result saved to: %s", output_json_path)
 
-        # 작업 성공 완료 처리
-        self.update_state(state="SUCCESS")
+        self.update_state(
+            state=JobStatus.COMPLETED.value,
+            meta=_build_task_meta(100, CurrentStage.FINALIZING),
+        )
         return result
-
-    except Exception as e:
-        # 에러 핸들링 및 상태 보고
+    except Exception as error:
         error_code = ErrorCode.UNKNOWN_ERROR
-        error_msg = str(e)
+        error_message = str(error)
 
-        # 1. GPU 메모리 부족 (OOM) 처리
-        if "out of memory" in error_msg.lower() or isinstance(
-            e, torch.cuda.OutOfMemoryError
+        if "out of memory" in error_message.lower() or isinstance(
+            error,
+            torch.cuda.OutOfMemoryError,
         ):
             error_code = ErrorCode.GPU_OOM
-            error_msg = "GPU Out of Memory. Please try a smaller model or batch size."
-            # 다음 작업을 위해 모델 언로드 (Recovery)
+            error_message = (
+                "GPU Out of Memory. Please try a smaller model or batch size."
+            )
             current_stt_service.unload_model()
+        elif isinstance(error, FileNotFoundError):
+            error_code = ErrorCode.INVALID_OPTIONS
+            error_message = f"Audio file not found: {file_path}"
 
-        # 2. 파일 없음 / 형식 오류 처리
-        elif isinstance(e, FileNotFoundError):
-            error_code = ErrorCode.FILE_NOT_SUPPORTED
-            error_msg = f"Audio file not found: {file_path}"
-
-        logger.exception(f"Task failed: [{error_code}] {error_msg}")
-
-        # API 서버가 파싱할 수 있도록 JSON 형태의 에러 메시지를 담아 예외 발생
-        raise Exception(json.dumps({"code": error_code, "message": error_msg}))
+        logger.exception("Task failed: [%s] %s", error_code.value, error_message)
+        self.update_state(
+            state=JobStatus.FAILED.value,
+            meta=_build_task_meta(
+                0,
+                CurrentStage.FINALIZING,
+                error_code=error_code,
+                error_message=error_message,
+            ),
+        )
+        raise Exception(
+            json.dumps({"code": error_code.value, "message": error_message})
+        )


### PR DESCRIPTION
## 작업 개요
- AI 모듈의 분석 요청/결과 스키마와 작업 상태 응답 구조를 백엔드 계약 기준으로 정리
- 기존 FastAPI + Celery 실행 흐름은 유지하고, 1주차 범위인 입력/상태/결과 스키마 및 상태 조회 응답 규격만 우선 반영

## 관련 이슈
- close #35 

## 작업 내용
- `SourceType`, `JobType`, `JobStatus`, `CurrentStage`, `TranslationProvider`, `ErrorCode` enum 추가
- `AnalysisRequest`를 `sourceType`, `fileUrl`, `sourceUrl`, `jobType` 기준으로 재정의
- `WorkerJobPayload` 스키마 추가
- `SubtitleSegment`, `OcrItem`, `LearningData`, `AnalysisMetadata`, `AnalysisResult` 모델 추가
- `CallbackPayload` 모델 추가
- Celery task 상태값을 `RUNNING / COMPLETED / FAILED` 기준으로 정리
- task meta에 `currentStage`, `errorCode`, `errorMessage` 반영
- `/status/{jobId}` 응답이 `currentStage`, `errorCode`, `errorMessage`를 반환하도록 수정
- `/analyze`가 새 `AnalysisRequest`를 사용하도록 수정


## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
- 없음

## 기타 사항
- 현재 `/analyze`는 기존 실행 흐름 호환을 위해 로컬 `fileUrl` 경로를 임시 지원 중입니다.
- 실제 BE -> AI 실행 흐름은 후속 작업에서 `WorkerJobPayload` 기반으로 연결할 예정입니다.
- README의 AI 요청 예시는 아직 구버전(`file_path`) 설명이 남아 있어 후속 문서 정리할 예정입니다.