### PR TITLE
feat: 공통 실행 파이프라인 및 작업 저장 구조 정리

### DIFF
--- a/ai/.env.example
+++ b/ai/.env.example
@@ -11,3 +11,12 @@ DB_PORT=5432
 DB_NAME=overlang
 DB_USERNAME=your_username
 DB_PASSWORD=your_password
+
+# Internal callback
+# If AI runs in Docker and backend runs on the host machine, use host.docker.internal.
+# If backend also runs in Docker Compose, use the backend service name instead of localhost.
+BACKEND_INTERNAL_BASE_URL=http://host.docker.internal:8080
+WORKER_SECRET=overlang-worker-secret
+CALLBACK_STRICT=false
+CALLBACK_RETRY_COUNT=3
+CALLBACK_RETRY_DELAY_SECONDS=1.0

--- a/ai/api/routes.py
+++ b/ai/api/routes.py
@@ -1,6 +1,4 @@
 import json
-
-from celery.result import AsyncResult
 from fastapi import APIRouter
 
 from ai.api.schemas import (
@@ -18,13 +16,9 @@ router = APIRouter()
 
 @router.post("/analyze", response_model=AnalysisResponse)
 async def analyze_audio(request: AnalysisRequest):
-    options = dict(request.options or {})
-    if request.source_language:
-        options["language"] = request.source_language
-
     task = celery_app.send_task(
-        "ai.worker.tasks.process_audio_task",
-        args=[request.resolve_local_input_path(), options],
+        "ai.worker.tasks.process_job_task",
+        args=[request.model_dump(by_alias=True)],
     )
 
     return AnalysisResponse(
@@ -36,7 +30,7 @@ async def analyze_audio(request: AnalysisRequest):
 
 @router.get("/status/{job_id}", response_model=TaskStatusResponse)
 async def get_task_status(job_id: str):
-    task_result = AsyncResult(job_id)
+    task_result = celery_app.AsyncResult(job_id)
     task_info = task_result.info if isinstance(task_result.info, dict) else {}
 
     response = TaskStatusResponse(
@@ -55,7 +49,7 @@ async def get_task_status(job_id: str):
         response.status = JobStatus.RUNNING
         return response
 
-    if task_result.state == JobStatus.COMPLETED.value:
+    if task_result.state in {JobStatus.COMPLETED.value, "SUCCESS"}:
         response.status = JobStatus.COMPLETED
         response.progress = 100.0
         response.current_stage = (

--- a/ai/api/routes.py
+++ b/ai/api/routes.py
@@ -1,78 +1,97 @@
-from fastapi import APIRouter
-from ai.api.schemas import AnalysisRequest, AnalysisResponse, TaskStatusResponse
-from ai.worker.celery_app import celery_app
+import json
+
 from celery.result import AsyncResult
+from fastapi import APIRouter
+
+from ai.api.schemas import (
+    AnalysisRequest,
+    AnalysisResponse,
+    CurrentStage,
+    ErrorCode,
+    JobStatus,
+    TaskStatusResponse,
+)
+from ai.worker.celery_app import celery_app
 
 router = APIRouter()
 
 
 @router.post("/analyze", response_model=AnalysisResponse)
 async def analyze_audio(request: AnalysisRequest):
-    """
-    오디오 분석 작업을 요청.
-    Celery Worker에게 작업을 비동기로 전달하고, 작업 ID(Job ID)를 즉시 반환.
+    options = dict(request.options or {})
+    if request.source_language:
+        options["language"] = request.source_language
 
-    Args:
-        request.file_path: 분석할 오디오 파일 경로 (Docker 내부 경로)
-        request.options: 분석 옵션 (모델명, 언어, 배치 사이즈 등)
-
-    Returns:
-        jobId: 작업 추적 ID
-        status: PENDING (작업 대기 중)
-    """
-    # Celery 작업 큐에 작업 추가 (비동기)
-    # send_task를 사용하여 Worker 코드와의 의존성을 분리.
     task = celery_app.send_task(
-        "ai.worker.tasks.process_audio_task", args=[request.file_path, request.options]
+        "ai.worker.tasks.process_audio_task",
+        args=[request.resolve_local_input_path(), options],
     )
 
     return AnalysisResponse(
-        job_id=task.id, status="PENDING", message="Task submitted successfully"
+        job_id=task.id,
+        status=JobStatus.PENDING,
+        message="Task submitted successfully",
     )
 
 
 @router.get("/status/{job_id}", response_model=TaskStatusResponse)
 async def get_task_status(job_id: str):
-    """
-    특정 작업(Job ID)의 현재 상태와 결과를 조회.
-
-    Returns:
-        status: PENDING, PROCESSING, SUCCESS, FAILURE 중 하나
-        progress: 진행률 (0.0 ~ 100.0)
-        result: 완료된 경우 분석 결과 데이터
-        errorCode: 실패 시 에러 코드
-        errorMessage: 실패 시 에러 메시지
-    """
     task_result = AsyncResult(job_id)
+    task_info = task_result.info if isinstance(task_result.info, dict) else {}
 
     response = TaskStatusResponse(
-        job_id=job_id, status=task_result.status, progress=0.0
+        job_id=job_id,
+        status=JobStatus.PENDING,
+        progress=float(task_info.get("progress", 0.0)),
+        current_stage=parse_current_stage(task_info.get("current_stage")),
     )
 
-    if task_result.state == "PENDING":
-        response.status = "PENDING"
-    elif task_result.state == "PROCESSING":
-        response.status = "PROCESSING"
-        if isinstance(task_result.info, dict):
-            response.progress = float(task_result.info.get("progress", 0))
-    elif task_result.state == "SUCCESS":
-        response.status = "SUCCESS"
+    if task_result.state == JobStatus.PENDING.value:
+        response.status = JobStatus.PENDING
+        response.current_stage = CurrentStage.QUEUED
+        return response
+
+    if task_result.state == JobStatus.RUNNING.value:
+        response.status = JobStatus.RUNNING
+        return response
+
+    if task_result.state == JobStatus.COMPLETED.value:
+        response.status = JobStatus.COMPLETED
         response.progress = 100.0
+        response.current_stage = (
+            parse_current_stage(task_info.get("current_stage"))
+            or CurrentStage.FINALIZING
+        )
         response.result = task_result.result
-    elif task_result.state == "FAILURE":
-        response.status = "FAILURE"
-        # Worker에서 발생한 에러 정보를 파싱.
+        return response
+
+    if task_result.state in {JobStatus.FAILED.value, "FAILURE"}:
+        response.status = JobStatus.FAILED
+        response.current_stage = (
+            parse_current_stage(task_info.get("current_stage"))
+            or CurrentStage.FINALIZING
+        )
+        response.progress = float(task_info.get("progress", 0.0))
+
         error_str = str(task_result.info)
         try:
-            # Worker가 JSON 형태로 에러를 던졌다면 파싱해서 구조화된 정보를 반환.
-            import json
-
             error_data = json.loads(error_str)
             response.error_code = error_data.get("code")
             response.error_message = error_data.get("message")
         except (json.JSONDecodeError, TypeError):
-            # 일반 파이썬 예외인 경우 그대로 반환
-            response.error_code = "WORKER_999"  # UNKNOWN
+            response.error_code = ErrorCode.UNKNOWN_ERROR
             response.error_message = error_str
 
+        return response
+
     return response
+
+
+def parse_current_stage(value: str | None) -> CurrentStage | None:
+    if not value:
+        return None
+
+    try:
+        return CurrentStage(value)
+    except ValueError:
+        return None

--- a/ai/api/schemas.py
+++ b/ai/api/schemas.py
@@ -1,56 +1,214 @@
-from pydantic import BaseModel, ConfigDict
-from typing import Optional, Any
+from __future__ import annotations
+
 from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SourceType(str, Enum):
+    UPLOAD = "UPLOAD"
+    YOUTUBE = "YOUTUBE"
+
+
+class JobType(str, Enum):
+    FULL_ANALYSIS = "FULL_ANALYSIS"
+    STT_ONLY = "STT_ONLY"
+    OCR_ONLY = "OCR_ONLY"
+    TRANSLATION_ONLY = "TRANSLATION_ONLY"
+    RETRY = "RETRY"
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class CurrentStage(str, Enum):
+    QUEUED = "QUEUED"
+    AUDIO_EXTRACTION = "AUDIO_EXTRACTION"
+    STT_TRANSCRIPTION = "STT_TRANSCRIPTION"
+    WHISPER_ALIGNMENT = "WHISPER_ALIGNMENT"
+    OCR_FRAME_EXTRACTION = "OCR_FRAME_EXTRACTION"
+    OCR_TEXT_DETECTION = "OCR_TEXT_DETECTION"
+    TRANSLATION = "TRANSLATION"
+    LLM_ANALYSIS = "LLM_ANALYSIS"
+    MERGING_RESULTS = "MERGING_RESULTS"
+    FINALIZING = "FINALIZING"
+
+
+class TranslationProvider(str, Enum):
+    DEFAULT = "DEFAULT"
+    DEEPL = "DEEPL"
+    OPENAI = "OPENAI"
 
 
 class ErrorCode(str, Enum):
-    """
-    Worker에서 발생할 수 있는 에러 코드 정의.
-    FE는 이 코드를 기반으로 사용자에게 적절한 안내 메시지를 표시해야 함.
-    """
-
-    GPU_OOM = "WORKER_001"  # GPU 메모리 부족
-    FILE_NOT_SUPPORTED = "WORKER_002"  # 지원하지 않는 파일 또는 파일 없음
-    UNKNOWN_ERROR = "WORKER_999"  # 알 수 없는 에러
+    GPU_OOM = "WORKER_001"
+    FFMPEG_ERROR = "WORKER_002"
+    LLM_TOKEN_EXCEEDED = "WORKER_003"
+    OCR_ENGINE_FAILED = "WORKER_004"
+    MODEL_LOAD_FAILED = "WORKER_005"
+    VIDEO_TOO_LONG = "WORKER_006"
+    INVALID_OPTIONS = "WORKER_007"
+    AUTH_FAILED = "WORKER_008"
+    TIMEOUT = "WORKER_009"
+    DOWNLOAD_FAILED = "WORKER_010"
+    UNKNOWN_ERROR = "WORKER_999"
 
 
 class CamelModel(BaseModel):
-    """
-    기본 Pydantic 설정을 담은 베이스 모델.
-    JSON 변환 시 snake_case를 CamelCase로 자동 변환.
-    """
-
     model_config = ConfigDict(
         populate_by_name=True,
-        alias_generator=lambda s: "".join(
-            word.capitalize() if i > 0 else word for i, word in enumerate(s.split("_"))
+        alias_generator=lambda value: "".join(
+            word.capitalize() if index > 0 else word
+            for index, word in enumerate(value.split("_"))
         ),
+        use_enum_values=True,
     )
 
 
 class AnalysisRequest(CamelModel):
-    """분석 요청 메타데이터"""
+    source_type: SourceType
+    file_url: str | None = None
+    source_url: str | None = None
+    job_type: JobType = JobType.FULL_ANALYSIS
+    source_language: str | None = None
+    target_language: str | None = None
+    translation_provider: TranslationProvider = TranslationProvider.DEFAULT
+    use_user_api_key: bool = False
+    options: dict[str, Any] | None = None
 
-    file_path: str  # 분석할 오디오 파일의 절대 경로
-    options: Optional[dict] = (
-        None  # 추가 분석 옵션 (예: {"no_align": true, "language": "ko"})
-    )
+    @model_validator(mode="after")
+    def validate_source_fields(self) -> "AnalysisRequest":
+        if self.source_type == SourceType.UPLOAD and not self.file_url:
+            raise ValueError("fileUrl is required when sourceType is UPLOAD")
+
+        if self.source_type == SourceType.YOUTUBE and not self.source_url:
+            raise ValueError("sourceUrl is required when sourceType is YOUTUBE")
+
+        return self
+
+    def resolve_local_input_path(self) -> str:
+        if self.source_type != SourceType.UPLOAD or not self.file_url:
+            raise ValueError(
+                "The current analyze API only supports local fileUrl uploads"
+            )
+
+        if self.file_url.startswith("file://"):
+            return self.file_url.removeprefix("file://")
+
+        return self.file_url
+
+
+class WorkerJobPayload(CamelModel):
+    job_id: int | str
+    project_id: int | str
+    source_type: SourceType
+    source_url: str | None = None
+    file_key: str | None = None
+    presigned_url: str | None = None
+    job_type: JobType = JobType.FULL_ANALYSIS
+    source_language: str | None = None
+    target_language: str | None = None
+    translation_provider: TranslationProvider = TranslationProvider.DEFAULT
+    use_user_api_key: bool = False
+
+    @model_validator(mode="after")
+    def validate_worker_payload(self) -> "WorkerJobPayload":
+        if self.source_type == SourceType.UPLOAD and not self.presigned_url:
+            raise ValueError("presignedUrl is required when sourceType is UPLOAD")
+
+        if self.source_type == SourceType.YOUTUBE and not self.source_url:
+            raise ValueError("sourceUrl is required when sourceType is YOUTUBE")
+
+        return self
+
+
+class WordTiming(CamelModel):
+    word: str
+    start_time: float | None = None
+    end_time: float | None = None
+    confidence: float | None = None
+
+
+class SubtitleSegment(CamelModel):
+    seq: int
+    start_time: float
+    end_time: float
+    text: str
+    translated_text: str | None = None
+    language_code: str | None = None
+    words: list[WordTiming] = Field(default_factory=list)
+
+
+class BoundingBox(CamelModel):
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class OcrItem(CamelModel):
+    start_time: float
+    end_time: float
+    origin_text: str
+    translated_text: str | None = None
+    bounding_box: BoundingBox
+    confidence: float | None = None
+
+
+class LearningData(CamelModel):
+    keywords: list[str] = Field(default_factory=list)
+    summary: str | None = None
+    expression_notes: list[str] = Field(default_factory=list)
+
+
+class AnalysisMetadata(CamelModel):
+    job_id: int | str
+    source_type: SourceType
+    source_language: str | None = None
+    target_language: str | None = None
+    duration: float | None = None
+    video_width: int | None = None
+    video_height: int | None = None
+    pipeline: list[str] = Field(default_factory=list)
+    fallback_used: bool = False
+
+
+class AnalysisResult(CamelModel):
+    subtitles: list[SubtitleSegment] = Field(default_factory=list)
+    ocr_items: list[OcrItem] = Field(default_factory=list)
+    learning_data: LearningData | None = None
+    metadata: AnalysisMetadata | None = None
+    warnings: list[str] = Field(default_factory=list)
 
 
 class AnalysisResponse(CamelModel):
-    """작업 생성 응답"""
-
-    job_id: str  # 생성된 작업 ID (GUID)
-    status: str  # 초기 상태 (PENDING)
-    message: str  # 응답 메시지
+    job_id: str
+    status: JobStatus
+    message: str
 
 
 class TaskStatusResponse(CamelModel):
-    """작업 상태 조회 응답"""
-
     job_id: str
-    status: str  # PENDING, PROCESSING, SUCCESS, FAILURE
-    progress: float  # 0.0 ~ 100.0
-    result: Optional[Any] = None  # 성공 시 결과 데이터
-    error_code: Optional[ErrorCode] = None  # 실패 시 에러 코드
-    error_message: Optional[str] = None  # 실패 시 상세 메시지
+    status: JobStatus
+    progress: float
+    current_stage: CurrentStage | None = None
+    result: AnalysisResult | dict[str, Any] | list[dict[str, Any]] | None = None
+    error_code: ErrorCode | str | None = None
+    error_message: str | None = None
+
+
+class CallbackPayload(CamelModel):
+    job_id: int | str
+    status: JobStatus
+    progress: float
+    current_stage: CurrentStage
+    segments: list[SubtitleSegment] = Field(default_factory=list)
+    ocr_items: list[OcrItem] = Field(default_factory=list)
+    learning_data: LearningData | None = None
+    error_code: ErrorCode | str | None = None
+    error_message: str | None = None

--- a/ai/main.py
+++ b/ai/main.py
@@ -1,14 +1,14 @@
-import argparse
-import logging
-import json
-import os
-import time
-import torch
-import warnings
-from typing import List, Dict, Any
-from stt_service import STTService
+from __future__ import annotations
 
-# 로깅 설정
+import argparse
+import json
+import logging
+import time
+from pathlib import Path
+
+from ai.api.schemas import AnalysisRequest, JobType, SourceType, TranslationProvider
+from ai.pipeline.run_pipeline import run_pipeline
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -16,117 +16,91 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-warnings.filterwarnings("ignore", category=UserWarning)
 
-# PyTorch Patch (for Safe Globals)
-if hasattr(torch.serialization, "add_safe_globals"):
-    original_load = torch.serialization.load
-
-    def patched_load(*args, **kwargs):
-        kwargs["weights_only"] = False
-        return original_load(*args, **kwargs)
-
-    torch.load = patched_load
-    torch.serialization.load = patched_load
-
-
-def save_to_json(data: List[Dict[str, Any]], output_path: str):
-    try:
-        with open(output_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        logger.info(f"Saved results to: {output_path}")
-    except Exception as e:
-        logger.error(f"Failed to save JSON: {e}")
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="OverLang AI CLI")
-
-    # Input/Output
+    parser.add_argument("--input", type=str, required=True, help="Input media file path")
+    parser.add_argument("--output", type=str, default="result.json", help="Output JSON path")
     parser.add_argument(
-        "--input", type=str, required=True, help="Input audio file path"
-    )
-    parser.add_argument(
-        "--output", type=str, default="result.json", help="Output JSON path"
-    )
-
-    # Model Config
-    parser.add_argument(
-        "--model",
+        "--job-type",
         type=str,
-        default="large-v2",
-        help="Whisper model size (default: large-v2)",
+        default=JobType.FULL_ANALYSIS.value,
+        choices=[job_type.value for job_type in JobType],
+        help="Pipeline job type",
     )
-    parser.add_argument(
-        "--device",
-        type=str,
-        default="cuda",
-        choices=["cuda", "cpu"],
-        help="Execution device",
-    )
+    parser.add_argument("--model", type=str, default="large-v3-turbo", help="Whisper model size")
     parser.add_argument(
         "--compute-type",
         type=str,
         default="float16",
-        help="Compute type (float16, int8)",
-    )
-
-    # Runtime Config
-    parser.add_argument(
-        "--batch-size", type=int, default=16, help="Batch size for transcription"
+        help="Compute type (float16, int8_float16, int8)",
     )
     parser.add_argument(
-        "--language", type=str, default=None, help="Language code (ko, en...)"
+        "--batch-size",
+        type=int,
+        default=16,
+        help="Batch size for transcription",
     )
     parser.add_argument(
-        "--no-align", action="store_true", help="Skip alignment step for speed"
+        "--language",
+        type=str,
+        default=None,
+        help="Source language code (ko, en, ja...)",
     )
     parser.add_argument(
-        "--warmup", action="store_true", help="Load model immediately on start"
+        "--target-language",
+        type=str,
+        default=None,
+        help="Target language code",
+    )
+    parser.add_argument(
+        "--translation-provider",
+        type=str,
+        default=TranslationProvider.DEFAULT.value,
+        choices=[provider.value for provider in TranslationProvider],
+        help="Translation provider identifier",
+    )
+    parser.add_argument(
+        "--no-align",
+        action="store_true",
+        help="Skip alignment step for speed",
     )
 
     args = parser.parse_args()
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    # 0. File Check
-    if not os.path.exists(args.input):
-        logger.error(f"Input file not found: {args.input}")
-        return
+    request = AnalysisRequest(
+        source_type=SourceType.UPLOAD,
+        file_url=str(input_path.resolve()),
+        job_type=JobType(args.job_type),
+        source_language=args.language,
+        target_language=args.target_language,
+        translation_provider=TranslationProvider(args.translation_provider),
+        use_user_api_key=False,
+        options={
+            "model": args.model,
+            "compute_type": args.compute_type,
+            "batch_size": args.batch_size,
+            "no_align": args.no_align,
+        },
+    )
 
-    # 1. Initialize Service
-    try:
-        service = STTService(
-            device=args.device, model_name=args.model, compute_type=args.compute_type
-        )
+    def progress_callback(current_stage, progress, extra=None) -> None:
+        logger.info("Stage=%s Progress=%.1f", current_stage.value, progress)
 
-        # 2. Warmup (Optional)
-        if args.warmup:
-            logger.info("Warming up model...")
-            service.load_model()
+    start_time = time.time()
+    result = run_pipeline(request, progress_callback=progress_callback)
+    elapsed = time.time() - start_time
 
-        # 3. Process
-        start_time = time.time()
-        results = service.transcribe(
-            audio_path=args.input,
-            batch_size=args.batch_size,
-            language=args.language,
-            align=not args.no_align,  # CLI flag is 'no-align', so invert
-        )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as file:
+        json.dump(result.model_dump(by_alias=True), file, ensure_ascii=False, indent=2)
 
-        elapsed = time.time() - start_time
-        logger.info(f"Total processed in {elapsed:.2f}s")
-
-        # 4. Save
-        if results:
-            save_to_json(results, args.output)
-
-        # 5. Cleanup (CLI only - Server might keep it)
-        service.unload_model()
-
-    except Exception as e:
-        logger.error(f"Critical Error: {e}")
-        import traceback
-
-        traceback.print_exc()
+    logger.info("Saved results to: %s", output_path)
+    logger.info("Total processed in %.2fs", elapsed)
 
 
 if __name__ == "__main__":

--- a/ai/pipeline/__init__.py
+++ b/ai/pipeline/__init__.py
@@ -1,0 +1,27 @@
+from ai.pipeline.audio_service import extract_audio_to_wav
+from ai.pipeline.callback_client import send_callback
+from ai.pipeline.frame_service import extract_frames
+from ai.pipeline.input_service import resolve_input_source
+from ai.pipeline.result_store import (
+    BASE_TEMP_DIR,
+    cleanup,
+    ensure_job_dirs,
+    get_job_dir,
+    save_intermediate,
+    save_result,
+)
+from ai.pipeline.run_pipeline import run_pipeline
+
+__all__ = [
+    "BASE_TEMP_DIR",
+    "cleanup",
+    "ensure_job_dirs",
+    "extract_audio_to_wav",
+    "extract_frames",
+    "get_job_dir",
+    "resolve_input_source",
+    "run_pipeline",
+    "save_intermediate",
+    "save_result",
+    "send_callback",
+]

--- a/ai/pipeline/audio_service.py
+++ b/ai/pipeline/audio_service.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import ffmpeg
+
+
+def extract_audio_to_wav(
+    input_path: str | Path,
+    output_dir: str | Path,
+    sample_rate: int = 16000,
+) -> Path:
+    source_path = Path(input_path)
+    destination_dir = Path(output_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    if not source_path.exists():
+        raise FileNotFoundError(f"Input media file not found: {source_path}")
+
+    output_path = destination_dir / f"{source_path.stem}_16k.wav"
+
+    try:
+        (
+            ffmpeg.input(str(source_path))
+            .output(str(output_path), ac=1, ar=sample_rate)
+            .overwrite_output()
+            .run(quiet=True)
+        )
+    except ffmpeg.Error as error:
+        error_message = error.stderr.decode() if error.stderr else str(error)
+        raise RuntimeError(f"FFmpeg audio extraction failed: {error_message}") from error
+
+    return output_path

--- a/ai/pipeline/callback_client.py
+++ b/ai/pipeline/callback_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+
+from ai.api.schemas import CallbackPayload
+
+logger = logging.getLogger(__name__)
+
+
+def send_callback(payload: CallbackPayload) -> None:
+    base_url = os.getenv("BACKEND_INTERNAL_BASE_URL")
+    worker_secret = os.getenv("WORKER_SECRET")
+    callback_strict = os.getenv("CALLBACK_STRICT", "false").lower() == "true"
+    retry_count = int(os.getenv("CALLBACK_RETRY_COUNT", "3"))
+    retry_delay_seconds = float(os.getenv("CALLBACK_RETRY_DELAY_SECONDS", "1.0"))
+
+    if not base_url or not worker_secret:
+        return
+
+    callback_url = (
+        f"{base_url.rstrip('/')}/api/v1/internal/jobs/{payload.job_id}/callback"
+    )
+    request = urllib.request.Request(
+        callback_url,
+        data=json.dumps(payload.model_dump(by_alias=True)).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Worker-Secret": worker_secret,
+        },
+        method="POST",
+    )
+
+    last_error = None
+    for attempt in range(1, retry_count + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=10):
+                return
+        except urllib.error.URLError as error:
+            last_error = error
+            if attempt == retry_count:
+                break
+            time.sleep(retry_delay_seconds)
+
+    if callback_strict:
+        raise RuntimeError(f"Callback request failed: {last_error}") from last_error
+
+    logger.warning("Callback request skipped after retries: %s", last_error)

--- a/ai/pipeline/frame_service.py
+++ b/ai/pipeline/frame_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import ffmpeg
+
+
+def extract_frames(
+    input_path: str | Path,
+    output_dir: str | Path,
+    interval_seconds: float = 1.0,
+) -> list[dict[str, object]]:
+    source_path = Path(input_path)
+    destination_dir = Path(output_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    if not source_path.exists():
+        raise FileNotFoundError(f"Input media file not found: {source_path}")
+
+    output_pattern = destination_dir / "frame_%06d.png"
+    try:
+        (
+            ffmpeg.input(str(source_path))
+            .filter("fps", fps=f"1/{interval_seconds}")
+            .output(str(output_pattern), start_number=0)
+            .overwrite_output()
+            .run(quiet=True)
+        )
+    except ffmpeg.Error as error:
+        error_message = error.stderr.decode() if error.stderr else str(error)
+        raise RuntimeError(f"FFmpeg frame extraction failed: {error_message}") from error
+
+    frame_paths = sorted(destination_dir.glob("frame_*.png"))
+    frames = []
+    for index, frame_path in enumerate(frame_paths):
+        frames.append(
+            {
+                "frameIndex": index,
+                "timestamp": round(index * interval_seconds, 3),
+                "path": str(frame_path),
+            }
+        )
+
+    return frames

--- a/ai/pipeline/input_service.py
+++ b/ai/pipeline/input_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import shutil
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from ai.api.schemas import AnalysisRequest, SourceType, WorkerJobPayload
+
+
+def resolve_input_source(
+    job: AnalysisRequest | WorkerJobPayload,
+    video_dir: Path,
+    timeout_seconds: int = 60,
+) -> Path:
+    video_dir.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(job, AnalysisRequest):
+        return _resolve_analysis_request(job)
+
+    if job.source_type == SourceType.YOUTUBE:
+        raise NotImplementedError(
+            "YOUTUBE source resolution will be implemented after input_service skeleton."
+        )
+
+    if not job.presigned_url:
+        raise ValueError("presignedUrl is required when sourceType is UPLOAD")
+
+    if job.presigned_url.startswith("file://"):
+        return Path(job.presigned_url.removeprefix("file://"))
+
+    local_path = Path(job.presigned_url)
+    if local_path.exists():
+        return local_path
+
+    parsed_url = urllib.parse.urlparse(job.presigned_url)
+    if parsed_url.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported input scheme: {parsed_url.scheme}")
+
+    target_name = _resolve_target_filename(job.file_key, parsed_url.path)
+    target_path = video_dir / target_name
+
+    with urllib.request.urlopen(job.presigned_url, timeout=timeout_seconds) as response:
+        with target_path.open("wb") as file:
+            shutil.copyfileobj(response, file)
+
+    return target_path
+
+
+def _resolve_analysis_request(job: AnalysisRequest) -> Path:
+    if job.source_type != SourceType.UPLOAD or not job.file_url:
+        raise ValueError("The current analyze API only supports UPLOAD fileUrl input")
+
+    if job.file_url.startswith("file://"):
+        return Path(job.file_url.removeprefix("file://"))
+
+    local_path = Path(job.file_url)
+    if local_path.exists():
+        return local_path
+
+    raise NotImplementedError(
+        "Remote fileUrl handling for AnalysisRequest will be implemented after the worker flow."
+    )
+
+
+def _resolve_target_filename(file_key: str | None, url_path: str) -> str:
+    if file_key:
+        return Path(file_key).name
+
+    url_name = Path(url_path).name
+    if url_name:
+        return url_name
+
+    return "source.bin"

--- a/ai/pipeline/result_store.py
+++ b/ai/pipeline/result_store.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+BASE_TEMP_DIR = Path(tempfile.gettempdir()) / "overlang"
+JOB_SUBDIRECTORIES = ("video", "audio", "frames", "result")
+
+
+def get_job_dir(job_id: str | int) -> Path:
+    return BASE_TEMP_DIR / str(job_id)
+
+
+def ensure_job_dirs(job_id: str | int) -> dict[str, Path]:
+    job_dir = get_job_dir(job_id)
+    directories = {"root": job_dir}
+
+    for directory_name in JOB_SUBDIRECTORIES:
+        directory_path = job_dir / directory_name
+        directory_path.mkdir(parents=True, exist_ok=True)
+        directories[directory_name] = directory_path
+
+    return directories
+
+
+def save_result(job_id: str | int, result: dict[str, Any]) -> Path:
+    directories = ensure_job_dirs(job_id)
+    output_path = directories["result"] / "analysis_result.json"
+    _write_json(output_path, result)
+    return output_path
+
+
+def save_intermediate(job_id: str | int, stage: str, data: dict[str, Any] | list[Any]) -> Path:
+    directories = ensure_job_dirs(job_id)
+    safe_stage_name = stage.strip().replace(" ", "_").lower()
+    output_path = directories["result"] / f"{safe_stage_name}.json"
+    _write_json(output_path, data)
+    return output_path
+
+
+def cleanup(job_id: str | int, keep_result_files: bool = True) -> None:
+    job_dir = get_job_dir(job_id)
+    if not job_dir.exists():
+        return
+
+    if not keep_result_files:
+        shutil.rmtree(job_dir, ignore_errors=True)
+        return
+
+    for directory_name in ("video", "audio", "frames"):
+        shutil.rmtree(job_dir / directory_name, ignore_errors=True)
+
+
+def _write_json(path: Path, data: dict[str, Any] | list[Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(data, file, ensure_ascii=False, indent=2)

--- a/ai/pipeline/run_pipeline.py
+++ b/ai/pipeline/run_pipeline.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from ai.api.schemas import (
+    AnalysisMetadata,
+    AnalysisRequest,
+    AnalysisResult,
+    CurrentStage,
+    JobType,
+    SubtitleSegment,
+    WorkerJobPayload,
+)
+from ai.pipeline.audio_service import extract_audio_to_wav
+from ai.pipeline.frame_service import extract_frames
+from ai.pipeline.input_service import resolve_input_source
+from ai.pipeline.result_store import (
+    cleanup,
+    ensure_job_dirs,
+    save_intermediate,
+    save_result,
+)
+from ai.stt_service import STTService
+
+ProgressCallback = Callable[[CurrentStage, float, dict[str, Any] | None], None]
+
+
+def run_pipeline(
+    job: AnalysisRequest | WorkerJobPayload | dict[str, Any],
+    progress_callback: ProgressCallback | None = None,
+    job_id: str | int | None = None,
+    keep_intermediate_files: bool = True,
+) -> AnalysisResult:
+    normalized_job = _normalize_job(job)
+    resolved_job_id = _resolve_job_id(normalized_job, job_id)
+    directories = ensure_job_dirs(resolved_job_id)
+
+    try:
+        _report_progress(progress_callback, CurrentStage.QUEUED, 0.0)
+        save_intermediate(resolved_job_id, "request", _serialize_model(normalized_job))
+
+        source_path = resolve_input_source(normalized_job, directories["video"])
+        if not source_path.exists():
+            raise FileNotFoundError(f"Input source not found: {source_path}")
+
+        if normalized_job.job_type in {JobType.OCR_ONLY, JobType.TRANSLATION_ONLY}:
+            raise NotImplementedError(
+                f"{_enum_value(normalized_job.job_type)} is not wired into run_pipeline yet."
+            )
+
+        _report_progress(progress_callback, CurrentStage.AUDIO_EXTRACTION, 10.0)
+        audio_path = extract_audio_to_wav(source_path, directories["audio"])
+        save_intermediate(
+            resolved_job_id,
+            "audio_extraction",
+            {
+                "jobId": resolved_job_id,
+                "sourcePath": str(source_path),
+                "audioPath": str(audio_path),
+            },
+        )
+
+        _report_progress(progress_callback, CurrentStage.STT_TRANSCRIPTION, 20.0)
+        subtitles = _run_stt_stage(normalized_job, audio_path)
+        save_intermediate(
+            resolved_job_id,
+            "stt_subtitles",
+            [subtitle.model_dump(by_alias=True) for subtitle in subtitles],
+        )
+
+        pipeline_steps = ["STT"]
+        if normalized_job.job_type == JobType.FULL_ANALYSIS:
+            _report_progress(progress_callback, CurrentStage.OCR_FRAME_EXTRACTION, 40.0)
+            save_intermediate(
+                resolved_job_id,
+                "frame_extraction",
+                extract_frames(source_path, directories["frames"]),
+            )
+            pipeline_steps.append("OCR_FRAME_EXTRACTION")
+
+        _report_progress(progress_callback, CurrentStage.FINALIZING, 90.0)
+        result = AnalysisResult(
+            subtitles=subtitles,
+            metadata=AnalysisMetadata(
+                job_id=resolved_job_id,
+                source_type=normalized_job.source_type,
+                source_language=normalized_job.source_language,
+                target_language=normalized_job.target_language,
+                pipeline=pipeline_steps,
+                fallback_used=False,
+            ),
+        )
+        save_result(resolved_job_id, result.model_dump(by_alias=True))
+        save_intermediate(
+            resolved_job_id,
+            "pipeline_summary",
+            {
+                "jobId": resolved_job_id,
+                "inputPath": str(source_path),
+                "audioPath": str(audio_path),
+                "jobType": _enum_value(normalized_job.job_type),
+                "workingDirectory": str(directories["root"]),
+            },
+        )
+        _report_progress(progress_callback, CurrentStage.FINALIZING, 100.0)
+        return result
+    finally:
+        cleanup(resolved_job_id, keep_result_files=keep_intermediate_files)
+
+
+def _normalize_job(
+    job: AnalysisRequest | WorkerJobPayload | dict[str, Any],
+) -> AnalysisRequest | WorkerJobPayload:
+    if isinstance(job, (AnalysisRequest, WorkerJobPayload)):
+        return job
+
+    if any(key in job for key in ("jobId", "projectId", "presignedUrl")):
+        return WorkerJobPayload.model_validate(job)
+
+    return AnalysisRequest.model_validate(job)
+
+
+def _resolve_job_id(
+    job: AnalysisRequest | WorkerJobPayload,
+    job_id: str | int | None = None,
+) -> str | int:
+    if job_id is not None:
+        return job_id
+
+    if isinstance(job, WorkerJobPayload):
+        return job.job_id
+
+    return "local-run"
+
+
+def _run_stt_stage(
+    job: AnalysisRequest | WorkerJobPayload,
+    source_path: Path,
+) -> list[SubtitleSegment]:
+    runtime_options = _extract_runtime_options(job)
+    stt_service = STTService(
+        model_name=runtime_options["model"],
+        compute_type=runtime_options["compute_type"],
+    )
+    try:
+        raw_segments = stt_service.transcribe(
+            audio_path=str(source_path),
+            batch_size=runtime_options["batch_size"],
+            language=job.source_language,
+            align=runtime_options["align"],
+            model_name=runtime_options["model"],
+        )
+    finally:
+        stt_service.unload_model()
+
+    subtitles = []
+    for index, segment in enumerate(raw_segments, start=1):
+        subtitles.append(
+            SubtitleSegment(
+                seq=index,
+                start_time=float(segment["startTime"]),
+                end_time=float(segment["endTime"]),
+                text=segment["text"],
+                translated_text=None,
+                language_code=job.source_language,
+                words=[],
+            )
+        )
+
+    return subtitles
+
+
+def _serialize_model(
+    model: AnalysisRequest | WorkerJobPayload,
+) -> dict[str, Any]:
+    return model.model_dump(by_alias=True)
+
+
+def _extract_runtime_options(
+    job: AnalysisRequest | WorkerJobPayload,
+) -> dict[str, Any]:
+    options = {}
+    if isinstance(job, AnalysisRequest) and job.options:
+        options = dict(job.options)
+
+    return {
+        "model": options.get("model", "large-v3-turbo"),
+        "batch_size": int(options.get("batch_size", 16)),
+        "compute_type": options.get("compute_type", "float16"),
+        "align": not bool(options.get("no_align", False)),
+    }
+
+
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _report_progress(
+    callback: ProgressCallback | None,
+    current_stage: CurrentStage,
+    progress: float,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    if callback is None:
+        return
+
+    callback(current_stage, progress, extra)

--- a/ai/worker/tasks.py
+++ b/ai/worker/tasks.py
@@ -1,111 +1,117 @@
-from ai.worker.celery_app import celery_app
-from ai.stt_service import STTService
-import logging
-import warnings
 import json
+import logging
 import os
+import warnings
+
 import torch
-from ai.api.schemas import ErrorCode
+
+from ai.api.schemas import CurrentStage, ErrorCode, JobStatus
+from ai.stt_service import STTService
+from ai.worker.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
 
-# UserWarning 경고 무시 (WhisperX 내부 경고 등)
 warnings.filterwarnings("ignore", category=UserWarning)
 
-# 전역 변수로 STT 서비스 인스턴스를 유지
-# Worker 프로세스가 시작될 때 한 번만 초기화되며, 이후 요청에서는 재사용
 current_stt_service = STTService(model_name="large-v3-turbo")
 
 
+def _build_task_meta(
+    progress: float,
+    current_stage: CurrentStage,
+    error_code: ErrorCode | None = None,
+    error_message: str | None = None,
+) -> dict[str, object]:
+    return {
+        "progress": float(progress),
+        "current_stage": current_stage.value,
+        "error_code": error_code.value if isinstance(error_code, ErrorCode) else error_code,
+        "error_message": error_message,
+    }
+
+
 @celery_app.task(bind=True)
-def process_audio_task(self, file_path: str, options: dict = None):
-    """
-    비동기 음성 인식 작업 (Celery Task)
-
-    Args:
-        self: Task 인스턴스 (상태 업데이트용)
-        file_path (str): 분석할 오디오 파일의 절대 경로 (/app/ai/...)
-        options (dict): 분석 옵션 (model, batch_size, language, no_align 등)
-
-    Returns:
-        dict: 분석 결과 (Segments 리스트)
-    """
+def process_audio_task(self, file_path: str, options: dict | None = None):
     global current_stt_service
 
     try:
-        logger.info(f"Task started: {file_path}")
-        # 상태 업데이트: 0%
-        self.update_state(state="PROCESSING", meta={"progress": 0})
+        logger.info("Task started: %s", file_path)
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(0, CurrentStage.QUEUED),
+        )
 
-        if options is None:
-            options = {}
-
-        # 1. 옵션 파싱 - 요청된 모델 확인 (기본값은 현재 로드된 모델 사용)
+        options = options or {}
         target_model = options.get("model", current_stt_service.model_name)
         batch_size = options.get("batch_size", 16)
         no_align = options.get("no_align", False)
         language = options.get("language", "ko")
 
-        # 2. 모델 교체 로직 (VRAM 보호 및 최적화)
-        # 요청된 모델이 현재 로드된 모델과 다르면 교체 작업을 수행
         if current_stt_service.model_name != target_model:
             logger.info(
-                f"Switching Model: {current_stt_service.model_name} -> {target_model}"
+                "Switching model: %s -> %s",
+                current_stt_service.model_name,
+                target_model,
             )
-
-            # 기존 모델 메모리 해제 (VRAM 확보)
             current_stt_service.unload_model()
-
-            # 새 모델로 인스턴스화 및 로드
             current_stt_service = STTService(model_name=target_model)
             current_stt_service.load_model()
 
-        self.update_state(state="PROCESSING", meta={"progress": 20})
-
-        # 3. 분석 실행
-        logger.info(f"Calling transcribe... Model: {target_model}, Lang: {language}")
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(20, CurrentStage.STT_TRANSCRIPTION),
+        )
 
         result = current_stt_service.transcribe(
             audio_path=file_path,
             batch_size=batch_size,
-            align=not no_align,  # no_align이 True면 align은 False
+            align=not no_align,
             language=language,
         )
 
-        logger.info("Transcribe completed.")
-        self.update_state(state="PROCESSING", meta={"progress": 90})
+        self.update_state(
+            state=JobStatus.RUNNING.value,
+            meta=_build_task_meta(90, CurrentStage.FINALIZING),
+        )
 
-        # 4. 결과 파일 저장 - 원본 파일명 뒤에 _result.json을 붙여서 저장
         output_json_path = f"{os.path.splitext(file_path)[0]}_result.json"
-        with open(output_json_path, "w", encoding="utf-8") as f:
-            json.dump(result, f, ensure_ascii=False, indent=2)
+        with open(output_json_path, "w", encoding="utf-8") as file:
+            json.dump(result, file, ensure_ascii=False, indent=2)
 
-        logger.info(f"Result saved to: {output_json_path}")
+        logger.info("Result saved to: %s", output_json_path)
 
-        # 작업 성공 완료 처리
-        self.update_state(state="SUCCESS")
+        self.update_state(
+            state=JobStatus.COMPLETED.value,
+            meta=_build_task_meta(100, CurrentStage.FINALIZING),
+        )
         return result
-
-    except Exception as e:
-        # 에러 핸들링 및 상태 보고
+    except Exception as error:
         error_code = ErrorCode.UNKNOWN_ERROR
-        error_msg = str(e)
+        error_message = str(error)
 
-        # 1. GPU 메모리 부족 (OOM) 처리
-        if "out of memory" in error_msg.lower() or isinstance(
-            e, torch.cuda.OutOfMemoryError
+        if "out of memory" in error_message.lower() or isinstance(
+            error,
+            torch.cuda.OutOfMemoryError,
         ):
             error_code = ErrorCode.GPU_OOM
-            error_msg = "GPU Out of Memory. Please try a smaller model or batch size."
-            # 다음 작업을 위해 모델 언로드 (Recovery)
+            error_message = (
+                "GPU Out of Memory. Please try a smaller model or batch size."
+            )
             current_stt_service.unload_model()
+        elif isinstance(error, FileNotFoundError):
+            error_code = ErrorCode.INVALID_OPTIONS
+            error_message = f"Audio file not found: {file_path}"
 
-        # 2. 파일 없음 / 형식 오류 처리
-        elif isinstance(e, FileNotFoundError):
-            error_code = ErrorCode.FILE_NOT_SUPPORTED
-            error_msg = f"Audio file not found: {file_path}"
-
-        logger.exception(f"Task failed: [{error_code}] {error_msg}")
-
-        # API 서버가 파싱할 수 있도록 JSON 형태의 에러 메시지를 담아 예외 발생
-        raise Exception(json.dumps({"code": error_code, "message": error_msg}))
+        logger.exception("Task failed: [%s] %s", error_code.value, error_message)
+        self.update_state(
+            state=JobStatus.FAILED.value,
+            meta=_build_task_meta(
+                0,
+                CurrentStage.FINALIZING,
+                error_code=error_code,
+                error_message=error_message,
+            ),
+        )
+        raise Exception(
+            json.dumps({"code": error_code.value, "message": error_message})
+        )

--- a/ai/worker/tasks.py
+++ b/ai/worker/tasks.py
@@ -1,19 +1,25 @@
 import json
 import logging
-import os
 import warnings
 
 import torch
 
-from ai.api.schemas import CurrentStage, ErrorCode, JobStatus
-from ai.stt_service import STTService
+from ai.api.schemas import (
+    AnalysisRequest,
+    CallbackPayload,
+    CurrentStage,
+    ErrorCode,
+    JobStatus,
+    JobType,
+    SourceType,
+)
+from ai.pipeline.callback_client import send_callback
+from ai.pipeline.run_pipeline import run_pipeline
 from ai.worker.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
 
 warnings.filterwarnings("ignore", category=UserWarning)
-
-current_stt_service = STTService(model_name="large-v3-turbo")
 
 
 def _build_task_meta(
@@ -30,61 +36,67 @@ def _build_task_meta(
     }
 
 
-@celery_app.task(bind=True)
-def process_audio_task(self, file_path: str, options: dict | None = None):
-    global current_stt_service
+def _execute_job_task(self, job_payload: dict):
+    task_progress = {
+        "progress": 0.0,
+        "current_stage": CurrentStage.QUEUED,
+    }
+    input_reference = (
+        job_payload.get("fileUrl")
+        or job_payload.get("presignedUrl")
+        or job_payload.get("sourceUrl")
+        or "unknown-input"
+    )
 
     try:
-        logger.info("Task started: %s", file_path)
-        self.update_state(
-            state=JobStatus.RUNNING.value,
-            meta=_build_task_meta(0, CurrentStage.QUEUED),
-        )
+        logger.info("Task started: %s", self.request.id)
 
-        options = options or {}
-        target_model = options.get("model", current_stt_service.model_name)
-        batch_size = options.get("batch_size", 16)
-        no_align = options.get("no_align", False)
-        language = options.get("language", "ko")
-
-        if current_stt_service.model_name != target_model:
-            logger.info(
-                "Switching model: %s -> %s",
-                current_stt_service.model_name,
-                target_model,
+        def progress_callback(
+            current_stage: CurrentStage,
+            progress: float,
+            extra: dict | None = None,
+        ) -> None:
+            task_progress["progress"] = float(progress)
+            task_progress["current_stage"] = current_stage
+            self.update_state(
+                state=JobStatus.RUNNING.value,
+                meta=_build_task_meta(progress, current_stage),
             )
-            current_stt_service.unload_model()
-            current_stt_service = STTService(model_name=target_model)
-            current_stt_service.load_model()
+            send_callback(
+                CallbackPayload(
+                    job_id=self.request.id,
+                    status=JobStatus.RUNNING,
+                    progress=float(progress),
+                    current_stage=current_stage,
+                    segments=[],
+                    ocr_items=[],
+                    learning_data=None,
+                    error_code=None,
+                    error_message=None,
+                )
+            )
 
-        self.update_state(
-            state=JobStatus.RUNNING.value,
-            meta=_build_task_meta(20, CurrentStage.STT_TRANSCRIPTION),
+        result = run_pipeline(
+            job_payload,
+            progress_callback=progress_callback,
+            job_id=self.request.id,
+            keep_intermediate_files=True,
         )
 
-        result = current_stt_service.transcribe(
-            audio_path=file_path,
-            batch_size=batch_size,
-            align=not no_align,
-            language=language,
+        send_callback(
+            CallbackPayload(
+                job_id=self.request.id,
+                status=JobStatus.COMPLETED,
+                progress=100.0,
+                current_stage=CurrentStage.FINALIZING,
+                segments=result.subtitles,
+                ocr_items=result.ocr_items,
+                learning_data=result.learning_data,
+                error_code=None,
+                error_message=None,
+            )
         )
-
-        self.update_state(
-            state=JobStatus.RUNNING.value,
-            meta=_build_task_meta(90, CurrentStage.FINALIZING),
-        )
-
-        output_json_path = f"{os.path.splitext(file_path)[0]}_result.json"
-        with open(output_json_path, "w", encoding="utf-8") as file:
-            json.dump(result, file, ensure_ascii=False, indent=2)
-
-        logger.info("Result saved to: %s", output_json_path)
-
-        self.update_state(
-            state=JobStatus.COMPLETED.value,
-            meta=_build_task_meta(100, CurrentStage.FINALIZING),
-        )
-        return result
+        return result.model_dump(by_alias=True)
     except Exception as error:
         error_code = ErrorCode.UNKNOWN_ERROR
         error_message = str(error)
@@ -97,21 +109,56 @@ def process_audio_task(self, file_path: str, options: dict | None = None):
             error_message = (
                 "GPU Out of Memory. Please try a smaller model or batch size."
             )
-            current_stt_service.unload_model()
         elif isinstance(error, FileNotFoundError):
             error_code = ErrorCode.INVALID_OPTIONS
-            error_message = f"Audio file not found: {file_path}"
+            error_message = f"Input source not found: {input_reference}"
+        elif isinstance(error, NotImplementedError):
+            error_code = ErrorCode.INVALID_OPTIONS
+        elif isinstance(error, ValueError):
+            error_code = ErrorCode.INVALID_OPTIONS
+        elif "ffmpeg" in error_message.lower():
+            error_code = ErrorCode.FFMPEG_ERROR
 
         logger.exception("Task failed: [%s] %s", error_code.value, error_message)
         self.update_state(
             state=JobStatus.FAILED.value,
             meta=_build_task_meta(
-                0,
-                CurrentStage.FINALIZING,
+                float(task_progress["progress"]),
+                task_progress["current_stage"],
                 error_code=error_code,
                 error_message=error_message,
             ),
         )
+        send_callback(
+            CallbackPayload(
+                job_id=self.request.id,
+                status=JobStatus.FAILED,
+                progress=float(task_progress["progress"]),
+                current_stage=task_progress["current_stage"],
+                segments=[],
+                ocr_items=[],
+                learning_data=None,
+                error_code=error_code.value,
+                error_message=error_message,
+            )
+        )
         raise Exception(
             json.dumps({"code": error_code.value, "message": error_message})
         )
+
+
+@celery_app.task(bind=True)
+def process_job_task(self, job_payload: dict):
+    return _execute_job_task(self, job_payload)
+
+
+@celery_app.task(bind=True)
+def process_audio_task(self, file_path: str, options: dict | None = None):
+    job = AnalysisRequest(
+        source_type=SourceType.UPLOAD,
+        file_url=file_path,
+        job_type=JobType.FULL_ANALYSIS,
+        source_language=(options or {}).get("language"),
+        options=options or {},
+    )
+    return _execute_job_task(self, job.model_dump(by_alias=True))


### PR DESCRIPTION
## 작업 개요
CLI와 Celery가 동일한 흐름으로 실행되도록 공통 파이프라인 구조를 정리했습니다.  
입력 처리, 오디오 추출, 프레임 추출, 결과 저장, 상태 조회 흐름을 `run_pipeline()` 기준으로 통합했습니다.

## 관련 이슈
- close #40 

## 작업 내용
- `pipeline/run_pipeline.py` 추가 및 공통 실행 진입점 구성
- CLI / Celery 실행 흐름을 `run_pipeline()`으로 통합
- `pipeline/result_store.py` 추가 및 결과 저장 구조 정리
- `jobId` 기준 작업 디렉터리 구조 도입
- 중간 결과 / 최종 결과 저장 로직 구현
- `pipeline/input_service.py` 추가
  - UPLOAD 입력 처리
  - 로컬 경로 / `file://` / presignedUrl 지원
- `pipeline/audio_service.py` 추가
  - ffmpeg 기반 오디오 추출 로직 분리
- `pipeline/frame_service.py` 추가
  - 일정 간격 프레임 추출 연결
- `/status/{jobId}`가 Celery 실제 상태를 조회하도록 수정
- callback 실패 시 전체 파이프라인 실패로 전파되지 않도록 완화
 
## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="1529" height="1204" alt="image" src="https://github.com/user-attachments/assets/33f0ac41-5673-4090-9b8d-5696c6bf3ca5" />

## 기타 사항
- 현재 `FULL_ANALYSIS`는 STT + OCR 프레임 추출 단계까지 연결되어 있습니다.
- `YOUTUBE`, `OCR_ONLY`, `TRANSLATION_ONLY`는 아직 미구현 상태입니다.
- Backend callback은 구조 및 재시도 로직까지 구현되었으며, 실제 BE 서버 연동 검증은 후속 작업이 필요합니다.