### PR TITLE
feat: STT 자막 구조 안정화 및 실패 응답 보완

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ ai/test_audio*
 ai/test_audio*_result.json
 ai/test_audio*_16k.wav
 ai/benchmark.py
+ai/samples/

--- a/ai/api/routes.py
+++ b/ai/api/routes.py
@@ -63,9 +63,14 @@ async def get_task_status(job_id: str):
         response.status = JobStatus.FAILED
         response.current_stage = (
             parse_current_stage(task_info.get("current_stage"))
-            or CurrentStage.FINALIZING
+            or CurrentStage.QUEUED
         )
         response.progress = float(task_info.get("progress", 0.0))
+
+        if task_info.get("error_code") or task_info.get("error_message"):
+            response.error_code = task_info.get("error_code")
+            response.error_message = task_info.get("error_message")
+            return response
 
         error_str = str(task_result.info)
         try:

--- a/ai/pipeline/run_pipeline.py
+++ b/ai/pipeline/run_pipeline.py
@@ -10,6 +10,7 @@ from ai.api.schemas import (
     CurrentStage,
     JobType,
     SubtitleSegment,
+    WordTiming,
     WorkerJobPayload,
 )
 from ai.pipeline.audio_service import extract_audio_to_wav
@@ -44,7 +45,8 @@ def run_pipeline(
         if not source_path.exists():
             raise FileNotFoundError(f"Input source not found: {source_path}")
 
-        if normalized_job.job_type in {JobType.OCR_ONLY, JobType.TRANSLATION_ONLY}:
+        job_type = _enum_value(normalized_job.job_type)
+        if job_type in {JobType.OCR_ONLY.value, JobType.TRANSLATION_ONLY.value}:
             raise NotImplementedError(
                 f"{_enum_value(normalized_job.job_type)} is not wired into run_pipeline yet."
             )
@@ -62,7 +64,7 @@ def run_pipeline(
         )
 
         _report_progress(progress_callback, CurrentStage.STT_TRANSCRIPTION, 20.0)
-        subtitles = _run_stt_stage(normalized_job, audio_path)
+        subtitles = _run_stt_stage(normalized_job, audio_path, progress_callback)
         save_intermediate(
             resolved_job_id,
             "stt_subtitles",
@@ -70,7 +72,7 @@ def run_pipeline(
         )
 
         pipeline_steps = ["STT"]
-        if normalized_job.job_type == JobType.FULL_ANALYSIS:
+        if job_type == JobType.FULL_ANALYSIS.value:
             _report_progress(progress_callback, CurrentStage.OCR_FRAME_EXTRACTION, 40.0)
             save_intermediate(
                 resolved_job_id,
@@ -137,6 +139,7 @@ def _resolve_job_id(
 def _run_stt_stage(
     job: AnalysisRequest | WorkerJobPayload,
     source_path: Path,
+    progress_callback: ProgressCallback | None = None,
 ) -> list[SubtitleSegment]:
     runtime_options = _extract_runtime_options(job)
     stt_service = STTService(
@@ -150,25 +153,90 @@ def _run_stt_stage(
             language=job.source_language,
             align=runtime_options["align"],
             model_name=runtime_options["model"],
+            alignment_callback=lambda: _report_progress(
+                progress_callback,
+                CurrentStage.WHISPER_ALIGNMENT,
+                30.0,
+            ),
         )
     finally:
         stt_service.unload_model()
 
+    return _postprocess_subtitles(_build_subtitles(raw_segments, job.source_language))
+
+
+def _build_subtitles(
+    raw_segments: list[dict[str, Any]],
+    source_language: str | None,
+) -> list[SubtitleSegment]:
     subtitles = []
     for index, segment in enumerate(raw_segments, start=1):
         subtitles.append(
             SubtitleSegment(
                 seq=index,
-                start_time=float(segment["startTime"]),
-                end_time=float(segment["endTime"]),
-                text=segment["text"],
+                start_time=_round_time(segment["startTime"]),
+                end_time=_round_time(segment["endTime"]),
+                text=str(segment["text"]).strip(),
                 translated_text=None,
-                language_code=job.source_language,
-                words=[],
+                language_code=segment.get("languageCode") or source_language,
+                words=_build_word_timings(segment.get("words", [])),
             )
         )
 
     return subtitles
+
+
+def _build_word_timings(words: list[dict[str, Any]]) -> list[WordTiming]:
+    word_timings = []
+    for word in words:
+        text = str(word.get("word", "")).strip()
+        if not text:
+            continue
+
+        word_timings.append(
+            WordTiming(
+                word=text,
+                start_time=_optional_round_time(word.get("startTime")),
+                end_time=_optional_round_time(word.get("endTime")),
+                confidence=word.get("confidence"),
+            )
+        )
+
+    return word_timings
+
+
+def _postprocess_subtitles(
+    subtitles: list[SubtitleSegment],
+    min_duration_seconds: float = 0.2,
+) -> list[SubtitleSegment]:
+    cleaned_subtitles = [
+        subtitle
+        for subtitle in subtitles
+        if subtitle.text and subtitle.end_time > subtitle.start_time
+    ]
+    merged_subtitles: list[SubtitleSegment] = []
+
+    for subtitle in cleaned_subtitles:
+        duration = subtitle.end_time - subtitle.start_time
+        if (
+            merged_subtitles
+            and duration <= min_duration_seconds
+            and subtitle.language_code == merged_subtitles[-1].language_code
+        ):
+            previous = merged_subtitles[-1]
+            previous.end_time = _round_time(max(previous.end_time, subtitle.end_time))
+            previous.text = f"{previous.text} {subtitle.text}".strip()
+            previous.words.extend(subtitle.words)
+            continue
+
+        subtitle.start_time = _round_time(subtitle.start_time)
+        subtitle.end_time = _round_time(subtitle.end_time)
+        merged_subtitles.append(subtitle)
+
+    for index, subtitle in enumerate(merged_subtitles, start=1):
+        subtitle.seq = index
+
+    return merged_subtitles
 
 
 def _serialize_model(
@@ -194,6 +262,17 @@ def _extract_runtime_options(
 
 def _enum_value(value: Any) -> Any:
     return getattr(value, "value", value)
+
+
+def _round_time(value: Any) -> float:
+    return round(float(value), 3)
+
+
+def _optional_round_time(value: Any) -> float | None:
+    if value is None:
+        return None
+
+    return _round_time(value)
 
 
 def _report_progress(

--- a/ai/pipeline/run_pipeline.py
+++ b/ai/pipeline/run_pipeline.py
@@ -87,7 +87,10 @@ def run_pipeline(
             metadata=AnalysisMetadata(
                 job_id=resolved_job_id,
                 source_type=normalized_job.source_type,
-                source_language=normalized_job.source_language,
+                source_language=_resolve_source_language(
+                    normalized_job.source_language,
+                    subtitles,
+                ),
                 target_language=normalized_job.target_language,
                 pipeline=pipeline_steps,
                 fallback_used=False,
@@ -237,6 +240,20 @@ def _postprocess_subtitles(
         subtitle.seq = index
 
     return merged_subtitles
+
+
+def _resolve_source_language(
+    requested_language: str | None,
+    subtitles: list[SubtitleSegment],
+) -> str | None:
+    if requested_language:
+        return requested_language
+
+    for subtitle in subtitles:
+        if subtitle.language_code:
+            return subtitle.language_code
+
+    return None
 
 
 def _serialize_model(

--- a/ai/stt_service.py
+++ b/ai/stt_service.py
@@ -249,6 +249,7 @@ class STTService:
             result = self.model.transcribe(
                 audio, batch_size=batch_size, language=language
             )
+            detected_language = result.get("language")
 
             # 3. 정렬 수행
             if align:
@@ -263,7 +264,7 @@ class STTService:
                     "startTime": round(segment["start"], 3),
                     "endTime": round(segment["end"], 3),
                     "text": segment["text"].strip(),
-                    "languageCode": result.get("language"),
+                    "languageCode": detected_language,
                     "words": self._format_words(segment.get("words", [])),
                 }
                 formatted_results.append(item)

--- a/ai/stt_service.py
+++ b/ai/stt_service.py
@@ -7,7 +7,7 @@ import functools
 import pyannote.audio.core.inference
 import os
 import ffmpeg
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
 
 # PyTorch 2.6+ 보안 로드 이슈 해결 (UnpicklingError 방지용)
 try:
@@ -131,7 +131,7 @@ class STTService:
                 self.model = whisperx.load_model(
                     self.model_name,
                     self.device,
-                    compute_type="int8_float16",  # 메모리 최적화를 위해 int8_float16 사용
+                    compute_type=self.compute_type,
                 )
                 logger.info("Model loaded successfully.")
             except Exception as e:
@@ -221,6 +221,7 @@ class STTService:
         language: Optional[str] = None,
         align: bool = True,
         model_name: str = "base",
+        alignment_callback: Callable[[], None] | None = None,
     ) -> List[Dict[str, Any]]:
         """
         전체 음성 인식 파이프라인을 실행.
@@ -251,6 +252,8 @@ class STTService:
 
             # 3. 정렬 수행
             if align:
+                if alignment_callback is not None:
+                    alignment_callback()
                 result = self.align(result, audio, result["language"])
 
             # 4. 결과 포맷팅
@@ -260,6 +263,8 @@ class STTService:
                     "startTime": round(segment["start"], 3),
                     "endTime": round(segment["end"], 3),
                     "text": segment["text"].strip(),
+                    "languageCode": result.get("language"),
+                    "words": self._format_words(segment.get("words", [])),
                 }
                 formatted_results.append(item)
             return formatted_results
@@ -272,3 +277,28 @@ class STTService:
                         logger.info(f"Removed temporary file: {processed_path}")
                     except Exception as e:
                         logger.warning(f"Failed to remove temporary file: {e}")
+
+    def _format_words(self, words: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted_words = []
+        for word in words:
+            text = str(word.get("word", "")).strip()
+            if not text:
+                continue
+
+            formatted_words.append(
+                {
+                    "word": text,
+                    "startTime": _round_time(word.get("start")),
+                    "endTime": _round_time(word.get("end")),
+                    "confidence": word.get("score"),
+                }
+            )
+
+        return formatted_words
+
+
+def _round_time(value: Any) -> float | None:
+    if value is None:
+        return None
+
+    return round(float(value), 3)


### PR DESCRIPTION
## 작업 개요
 WhisperX 기반 STT 결과를 구조에 맞게 안정화했습니다.
 
STT 실행 옵션 반영, alignment 상태 분리, word timing 반영, 자막 후처리, 자동 감지 언어 반영, 실패 응답 보완을 처리했습니다. 또한, 테스트 과정에서 생성되는 AI 샘플 산출물이 Git에 포함되지 않도록 `.gitignore`를 정리했습니다.

## 관련 이슈
- close #42 
- close #43 

## 작업 내용
- WhisperX 모델 로딩 시 `compute_type` 옵션이 실제로 반영되도록 수정
- `WHISPER_ALIGNMENT` 단계가 progress callback에 반영되도록 수정
- WhisperX word timing 결과를 `subtitles[].words` 구조로 변환
- `sourceLanguage = null`일 때 자동 감지된 언어를 `subtitles[].languageCode`와 `metadata.sourceLanguage`에 반영
- 0.2초 이하 짧은 세그먼트를 직전 세그먼트와 병합
- 자막 시간값을 소수점 3자리로 정규화
- 파일 없음 실패 시 `/status/{jobId}` 응답에 worker의 `errorCode`, `errorMessage`가 유지되도록 수정
- 파일 확인 전 실패 시 `currentStage = QUEUED`로 반환되도록 수정
- 생성된 AI 샘플 출력 파일이 Git에 포함되지 않도록 `.gitignore` 정리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [ ] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항
- subtitle segment 분리 규칙, 무음 영상, 긴 영상, OOM 케이스 검증은 연동 후 처리 예정입니다.