### PR TITLE
feat: Job API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,12 +35,14 @@ dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'com.google.firebase:firebase-admin:9.2.0'
     implementation 'software.amazon.awssdk:s3:2.25.20'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 spotless {

--- a/backend/src/main/java/com/overlang/api/controller/JobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobController.java
@@ -1,0 +1,31 @@
+package com.overlang.api.controller;
+
+import com.overlang.api.dto.job.JobCreateRequest;
+import com.overlang.api.dto.job.JobCreateResponse;
+import com.overlang.domain.job.service.JobService;
+import com.overlang.global.auth.AuthInterceptor;
+import com.overlang.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class JobController {
+
+  private final JobService jobService;
+
+  @PostMapping("/projects/{projectId}/jobs")
+  public ApiResponse<JobCreateResponse> createJob(
+      @PathVariable Long projectId,
+      @RequestBody JobCreateRequest request,
+      HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    JobCreateResponse response = jobService.createJob(projectId, memberId, request);
+
+    return ApiResponse.success(response);
+  }
+}

--- a/backend/src/main/java/com/overlang/api/controller/JobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobController.java
@@ -2,10 +2,14 @@ package com.overlang.api.controller;
 
 import com.overlang.api.dto.job.JobCreateRequest;
 import com.overlang.api.dto.job.JobCreateResponse;
+import com.overlang.api.dto.job.JobDetailResponse;
+import com.overlang.api.dto.job.JobResponse;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +20,7 @@ public class JobController {
 
   private final JobService jobService;
 
+  @Operation(summary = "AI 작업 생성", description = "프로젝트에 대한 AI 처리 작업을 생성하고 Redis Queue에 등록합니다.")
   @PostMapping("/projects/{projectId}/jobs")
   public ApiResponse<JobCreateResponse> createJob(
       @PathVariable Long projectId,
@@ -25,6 +30,30 @@ public class JobController {
     Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
 
     JobCreateResponse response = jobService.createJob(projectId, memberId, request);
+
+    return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "프로젝트 작업 목록 조회", description = "프로젝트에 속한 AI 작업 목록을 조회합니다.")
+  @GetMapping("/projects/{projectId}/jobs")
+  public ApiResponse<List<JobResponse>> getJobsByProject(
+      @PathVariable Long projectId, HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    List<JobResponse> response = jobService.getJobsByProject(projectId, memberId);
+
+    return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "작업 상태 조회", description = "특정 AI 작업의 상태 및 진행 단계를 조회합니다.")
+  @GetMapping("/jobs/{jobId}")
+  public ApiResponse<JobDetailResponse> getJobDetail(
+      @PathVariable Long jobId, HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    JobDetailResponse response = jobService.getJobDetail(jobId, memberId);
 
     return ApiResponse.success(response);
   }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCreateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCreateRequest.java
@@ -1,0 +1,13 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.common.LanguageCode;
+import com.overlang.domain.job.entity.JobType;
+import com.overlang.domain.job.entity.TranslationProvider;
+
+public record JobCreateRequest(
+        JobType jobType,
+        LanguageCode sourceLanguage,
+        LanguageCode targetLanguage,
+        TranslationProvider translationProvider,
+        Boolean useUserApiKey
+) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
@@ -1,45 +1,42 @@
 package com.overlang.api.dto.job;
 
-import java.time.Instant;
 import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.job.entity.CurrentStage;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.entity.JobStatus;
 import com.overlang.domain.job.entity.JobType;
 import com.overlang.domain.job.entity.TranslationProvider;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record JobCreateResponse(
-        Long jobId,
-        Long projectId,
-        JobType jobType,
-        JobStatus status,
-        Integer progress,
-        CurrentStage currentStage,
-        LanguageCode sourceLanguage,
-        LanguageCode targetLanguage,
-        TranslationProvider translationProvider,
-        Boolean useUserApiKey,
-        String errorCode,
-        String errorMessage,
-        Instant createdAt
-) {
+    Long jobId,
+    Long projectId,
+    JobType jobType,
+    JobStatus status,
+    Integer progress,
+    CurrentStage currentStage,
+    LanguageCode sourceLanguage,
+    LanguageCode targetLanguage,
+    TranslationProvider translationProvider,
+    Boolean useUserApiKey,
+    String errorCode,
+    String errorMessage,
+    Instant createdAt) {
 
-    public static JobCreateResponse from(Job job) {
-        return new JobCreateResponse(
-                job.getId(),
-                job.getProject().getId(),
-                job.getJobType(),
-                job.getStatus(),
-                job.getProgress(),
-                job.getCurrentStage(),
-                job.getSourceLanguage(),
-                job.getTargetLanguage(),
-                job.getTranslationProvider(),
-                job.getUseUserApiKey(),
-                job.getErrorCode(),
-                job.getErrorMessage(),
-                job.getCreatedAt()
-        );
-    }
+  public static JobCreateResponse from(Job job) {
+    return new JobCreateResponse(
+        job.getId(),
+        job.getProject().getId(),
+        job.getJobType(),
+        job.getStatus(),
+        job.getProgress(),
+        job.getCurrentStage(),
+        job.getSourceLanguage(),
+        job.getTargetLanguage(),
+        job.getTranslationProvider(),
+        job.getUseUserApiKey(),
+        job.getErrorCode(),
+        job.getErrorMessage(),
+        job.getCreatedAt());
+  }
 }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
@@ -1,0 +1,45 @@
+package com.overlang.api.dto.job;
+
+import java.time.Instant;
+import com.overlang.domain.common.LanguageCode;
+import com.overlang.domain.job.entity.CurrentStage;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.entity.JobType;
+import com.overlang.domain.job.entity.TranslationProvider;
+import java.time.LocalDateTime;
+
+public record JobCreateResponse(
+        Long jobId,
+        Long projectId,
+        JobType jobType,
+        JobStatus status,
+        Integer progress,
+        CurrentStage currentStage,
+        LanguageCode sourceLanguage,
+        LanguageCode targetLanguage,
+        TranslationProvider translationProvider,
+        Boolean useUserApiKey,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt
+) {
+
+    public static JobCreateResponse from(Job job) {
+        return new JobCreateResponse(
+                job.getId(),
+                job.getProject().getId(),
+                job.getJobType(),
+                job.getStatus(),
+                job.getProgress(),
+                job.getCurrentStage(),
+                job.getSourceLanguage(),
+                job.getTargetLanguage(),
+                job.getTranslationProvider(),
+                job.getUseUserApiKey(),
+                job.getErrorCode(),
+                job.getErrorMessage(),
+                job.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobDetailResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobDetailResponse.java
@@ -9,37 +9,36 @@ import com.overlang.domain.job.entity.TranslationProvider;
 import java.time.Instant;
 
 public record JobDetailResponse(
-        Long jobId,
-        Long projectId,
-        JobType jobType,
-        JobStatus status,
-        Integer progress,
-        CurrentStage currentStage,
-        LanguageCode sourceLanguage,
-        LanguageCode targetLanguage,
-        TranslationProvider translationProvider,
-        Boolean useUserApiKey,
-        String errorCode,
-        String errorMessage,
-        Instant createdAt,
-        Instant updatedAt
-) {
+    Long jobId,
+    Long projectId,
+    JobType jobType,
+    JobStatus status,
+    Integer progress,
+    CurrentStage currentStage,
+    LanguageCode sourceLanguage,
+    LanguageCode targetLanguage,
+    TranslationProvider translationProvider,
+    Boolean useUserApiKey,
+    String errorCode,
+    String errorMessage,
+    Instant createdAt,
+    Instant updatedAt) {
 
-    public static JobDetailResponse from(Job job) {
-        return new JobDetailResponse(
-                job.getId(),
-                job.getProject().getId(),
-                job.getJobType(),
-                job.getStatus(),
-                job.getProgress(),
-                job.getCurrentStage(),
-                job.getSourceLanguage(),
-                job.getTargetLanguage(),
-                job.getTranslationProvider(),
-                job.getUseUserApiKey(),
-                job.getErrorCode(),
-                job.getErrorMessage(),
-                job.getCreatedAt(),
-                job.getUpdatedAt());
-    }
+  public static JobDetailResponse from(Job job) {
+    return new JobDetailResponse(
+        job.getId(),
+        job.getProject().getId(),
+        job.getJobType(),
+        job.getStatus(),
+        job.getProgress(),
+        job.getCurrentStage(),
+        job.getSourceLanguage(),
+        job.getTargetLanguage(),
+        job.getTranslationProvider(),
+        job.getUseUserApiKey(),
+        job.getErrorCode(),
+        job.getErrorMessage(),
+        job.getCreatedAt(),
+        job.getUpdatedAt());
+  }
 }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobDetailResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobDetailResponse.java
@@ -1,0 +1,45 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.common.LanguageCode;
+import com.overlang.domain.job.entity.CurrentStage;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.entity.JobType;
+import com.overlang.domain.job.entity.TranslationProvider;
+import java.time.Instant;
+
+public record JobDetailResponse(
+        Long jobId,
+        Long projectId,
+        JobType jobType,
+        JobStatus status,
+        Integer progress,
+        CurrentStage currentStage,
+        LanguageCode sourceLanguage,
+        LanguageCode targetLanguage,
+        TranslationProvider translationProvider,
+        Boolean useUserApiKey,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt,
+        Instant updatedAt
+) {
+
+    public static JobDetailResponse from(Job job) {
+        return new JobDetailResponse(
+                job.getId(),
+                job.getProject().getId(),
+                job.getJobType(),
+                job.getStatus(),
+                job.getProgress(),
+                job.getCurrentStage(),
+                job.getSourceLanguage(),
+                job.getTargetLanguage(),
+                job.getTranslationProvider(),
+                job.getUseUserApiKey(),
+                job.getErrorCode(),
+                job.getErrorMessage(),
+                job.getCreatedAt(),
+                job.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobResponse.java
@@ -9,35 +9,34 @@ import com.overlang.domain.job.entity.TranslationProvider;
 import java.time.Instant;
 
 public record JobResponse(
-        Long jobId,
-        Long projectId,
-        JobType jobType,
-        JobStatus status,
-        Integer progress,
-        CurrentStage currentStage,
-        LanguageCode sourceLanguage,
-        LanguageCode targetLanguage,
-        TranslationProvider translationProvider,
-        Boolean useUserApiKey,
-        String errorCode,
-        String errorMessage,
-        Instant createdAt
-) {
+    Long jobId,
+    Long projectId,
+    JobType jobType,
+    JobStatus status,
+    Integer progress,
+    CurrentStage currentStage,
+    LanguageCode sourceLanguage,
+    LanguageCode targetLanguage,
+    TranslationProvider translationProvider,
+    Boolean useUserApiKey,
+    String errorCode,
+    String errorMessage,
+    Instant createdAt) {
 
-    public static JobResponse from(Job job) {
-        return new JobResponse(
-                job.getId(),
-                job.getProject().getId(),
-                job.getJobType(),
-                job.getStatus(),
-                job.getProgress(),
-                job.getCurrentStage(),
-                job.getSourceLanguage(),
-                job.getTargetLanguage(),
-                job.getTranslationProvider(),
-                job.getUseUserApiKey(),
-                job.getErrorCode(),
-                job.getErrorMessage(),
-                job.getCreatedAt());
-    }
+  public static JobResponse from(Job job) {
+    return new JobResponse(
+        job.getId(),
+        job.getProject().getId(),
+        job.getJobType(),
+        job.getStatus(),
+        job.getProgress(),
+        job.getCurrentStage(),
+        job.getSourceLanguage(),
+        job.getTargetLanguage(),
+        job.getTranslationProvider(),
+        job.getUseUserApiKey(),
+        job.getErrorCode(),
+        job.getErrorMessage(),
+        job.getCreatedAt());
+  }
 }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobResponse.java
@@ -1,0 +1,43 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.common.LanguageCode;
+import com.overlang.domain.job.entity.CurrentStage;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.entity.JobType;
+import com.overlang.domain.job.entity.TranslationProvider;
+import java.time.Instant;
+
+public record JobResponse(
+        Long jobId,
+        Long projectId,
+        JobType jobType,
+        JobStatus status,
+        Integer progress,
+        CurrentStage currentStage,
+        LanguageCode sourceLanguage,
+        LanguageCode targetLanguage,
+        TranslationProvider translationProvider,
+        Boolean useUserApiKey,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt
+) {
+
+    public static JobResponse from(Job job) {
+        return new JobResponse(
+                job.getId(),
+                job.getProject().getId(),
+                job.getJobType(),
+                job.getStatus(),
+                job.getProgress(),
+                job.getCurrentStage(),
+                job.getSourceLanguage(),
+                job.getTargetLanguage(),
+                job.getTranslationProvider(),
+                job.getUseUserApiKey(),
+                job.getErrorCode(),
+                job.getErrorMessage(),
+                job.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/overlang/domain/common/LanguageCode.java
+++ b/backend/src/main/java/com/overlang/domain/common/LanguageCode.java
@@ -1,0 +1,27 @@
+package com.overlang.domain.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LanguageCode {
+  KO("ko", "한국어"),
+  EN("en", "영어"),
+  ZH("zh", "중국어"),
+  JA("ja", "일본어"),
+  ES("es", "스페인어"),
+  FR("fr", "프랑스어");
+
+  private final String code;
+  private final String description;
+
+  public static LanguageCode fromCode(String code) {
+    for (LanguageCode lang : values()) {
+      if (lang.code.equalsIgnoreCase(code)) {
+        return lang;
+      }
+    }
+    throw new IllegalArgumentException("지원하지 않는 언어 코드입니다: " + code);
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
+++ b/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
@@ -2,6 +2,7 @@ package com.overlang.domain.file.service;
 
 import com.overlang.api.dto.file.FileUploadResponse;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Service
 public class S3UploadService {
@@ -20,12 +24,15 @@ public class S3UploadService {
   private final S3Client s3Client;
   private final String bucket;
   private final String region;
+  private final S3Presigner s3Presigner;
 
   public S3UploadService(
       S3Client s3Client,
+      S3Presigner s3Presigner,
       @Value("${cloud.aws.s3.bucket}") String bucket,
       @Value("${cloud.aws.region.static}") String region) {
     this.s3Client = s3Client;
+    this.s3Presigner = s3Presigner;
     this.bucket = bucket;
     this.region = region;
   }
@@ -76,5 +83,22 @@ public class S3UploadService {
 
   private String buildFileUrl(String s3Key) {
     return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3Key;
+  }
+
+  public String generatePresignedGetUrl(String fileKey) {
+    if (fileKey == null || fileKey.isBlank()) {
+      throw new IllegalArgumentException("fileKey가 필요합니다.");
+    }
+
+    GetObjectRequest getObjectRequest =
+        GetObjectRequest.builder().bucket(bucket).key(fileKey).build();
+
+    GetObjectPresignRequest presignRequest =
+        GetObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(30))
+            .getObjectRequest(getObjectRequest)
+            .build();
+
+    return s3Presigner.presignGetObject(presignRequest).url().toString();
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/entity/Job.java
+++ b/backend/src/main/java/com/overlang/domain/job/entity/Job.java
@@ -1,6 +1,7 @@
 package com.overlang.domain.job.entity;
 
 import com.overlang.domain.common.BaseTimeEntity;
+import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.project.entity.Project;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,11 +35,13 @@ public class Job extends BaseTimeEntity { // 시간 자동 기록
   @Column(name = "current_stage", nullable = false)
   private CurrentStage currentStage;
 
-  @Column(name = "source_language", length = 20)
-  private String sourceLanguage;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "source_language", nullable = false, length = 20)
+  private LanguageCode sourceLanguage;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "target_language", nullable = false, length = 20)
-  private String targetLanguage;
+  private LanguageCode targetLanguage;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "translation_provider", length = 50)
@@ -56,8 +59,8 @@ public class Job extends BaseTimeEntity { // 시간 자동 기록
   public Job(
       Project project,
       JobType jobType,
-      String sourceLanguage,
-      String targetLanguage,
+      LanguageCode sourceLanguage,
+      LanguageCode targetLanguage,
       TranslationProvider translationProvider,
       Boolean useUserApiKey) {
     this.project = project;
@@ -89,6 +92,7 @@ public class Job extends BaseTimeEntity { // 시간 자동 기록
   }
 
   public void markFailed(String errorCode, String errorMessage) {
+    this.currentStage = CurrentStage.FINALIZING;
     this.status = JobStatus.FAILED;
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;

--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
@@ -1,10 +1,17 @@
-package com.overlang.api.dto.job;
+package com.overlang.domain.job.queue;
 
 import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.job.entity.JobType;
 import com.overlang.domain.job.entity.TranslationProvider;
+import com.overlang.domain.project.entity.SourceType;
 
-public record JobCreateRequest(
+public record JobQueuePayload(
+    Long jobId,
+    Long projectId,
+    SourceType sourceType,
+    String sourceUrl,
+    String fileKey,
+    String presignedUrl,
     JobType jobType,
     LanguageCode sourceLanguage,
     LanguageCode targetLanguage,

--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueueProducer.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueueProducer.java
@@ -1,0 +1,26 @@
+package com.overlang.domain.job.queue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JobQueueProducer {
+
+  private static final String JOB_QUEUE_KEY = "job-queue";
+
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public void enqueue(JobQueuePayload payload) {
+    try {
+      String jsonPayload = objectMapper.writeValueAsString(payload);
+      redisTemplate.opsForList().rightPush(JOB_QUEUE_KEY, jsonPayload);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Job queue payload 직렬화에 실패했습니다.", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -1,0 +1,12 @@
+package com.overlang.domain.job.repository;
+
+import com.overlang.domain.job.entity.Job;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+  List<Job> findByProjectIdOrderByCreatedAtDesc(Long projectId);
+
+  Optional<Job> findByIdAndProjectMemberId(Long jobId, Long memberId);
+}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -1,0 +1,110 @@
+package com.overlang.domain.job.service;
+
+import com.overlang.api.dto.job.JobCreateRequest;
+import com.overlang.api.dto.job.JobCreateResponse;
+import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.queue.JobQueuePayload;
+import com.overlang.domain.job.queue.JobQueueProducer;
+import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.entity.ProjectStatus;
+import com.overlang.domain.project.entity.SourceType;
+import com.overlang.domain.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+
+  private final ProjectRepository projectRepository;
+  private final JobRepository jobRepository;
+  private final S3UploadService s3UploadService;
+  private final JobQueueProducer jobQueueProducer;
+
+  @Transactional
+  public JobCreateResponse createJob(Long projectId, Long memberId, JobCreateRequest request) {
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
+    validateJobCreateRequest(request);
+
+    Job job =
+        new Job(
+            project,
+            request.jobType(),
+            request.sourceLanguage(),
+            request.targetLanguage(),
+            request.translationProvider(),
+            request.useUserApiKey());
+
+    Job savedJob = jobRepository.save(job);
+
+    project.updateStatus(ProjectStatus.PROCESSING);
+
+    JobQueuePayload payload = createQueuePayload(project, savedJob);
+
+    jobQueueProducer.enqueue(payload);
+
+    return JobCreateResponse.from(savedJob);
+  }
+
+  private void validateJobCreateRequest(JobCreateRequest request) {
+    if (request.jobType() == null) {
+      throw new IllegalArgumentException("jobType은 필수입니다.");
+    }
+
+    if (request.sourceLanguage() == null) {
+      throw new IllegalArgumentException("sourceLanguage는 필수입니다.");
+    }
+
+    if (request.targetLanguage() == null) {
+      throw new IllegalArgumentException("targetLanguage는 필수입니다.");
+    }
+
+    if (request.sourceLanguage() == request.targetLanguage()) {
+      throw new IllegalArgumentException("sourceLanguage와 targetLanguage는 같을 수 없습니다.");
+    }
+  }
+
+  private JobQueuePayload createQueuePayload(Project project, Job job) {
+    SourceType sourceType = project.getSourceType();
+
+    return switch (sourceType) {
+      case UPLOAD -> {
+        String presignedUrl = s3UploadService.generatePresignedGetUrl(project.getFileKey());
+
+        yield new JobQueuePayload(
+            job.getId(),
+            project.getId(),
+            sourceType,
+            null,
+            project.getFileKey(),
+            presignedUrl,
+            job.getJobType(),
+            job.getSourceLanguage(),
+            job.getTargetLanguage(),
+            job.getTranslationProvider(),
+            job.getUseUserApiKey());
+      }
+
+      case YOUTUBE ->
+          new JobQueuePayload(
+              job.getId(),
+              project.getId(),
+              sourceType,
+              project.getSourceUrl(),
+              null,
+              null,
+              job.getJobType(),
+              job.getSourceLanguage(),
+              job.getTargetLanguage(),
+              job.getTranslationProvider(),
+              job.getUseUserApiKey());
+    };
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -2,6 +2,8 @@ package com.overlang.domain.job.service;
 
 import com.overlang.api.dto.job.JobCreateRequest;
 import com.overlang.api.dto.job.JobCreateResponse;
+import com.overlang.api.dto.job.JobDetailResponse;
+import com.overlang.api.dto.job.JobResponse;
 import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.queue.JobQueuePayload;
@@ -11,6 +13,7 @@ import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -106,5 +109,27 @@ public class JobService {
               job.getTranslationProvider(),
               job.getUseUserApiKey());
     };
+  }
+
+  @Transactional(readOnly = true)
+  public List<JobResponse> getJobsByProject(Long projectId, Long memberId) {
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
+    return jobRepository.findByProjectIdOrderByCreatedAtDesc(project.getId()).stream()
+        .map(JobResponse::from)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public JobDetailResponse getJobDetail(Long jobId, Long memberId) {
+    Job job =
+        jobRepository
+            .findByIdAndProjectMemberId(jobId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+
+    return JobDetailResponse.from(job);
   }
 }

--- a/backend/src/main/java/com/overlang/global/config/S3Config.java
+++ b/backend/src/main/java/com/overlang/global/config/S3Config.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -25,6 +26,16 @@ public class S3Config {
     AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
     return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .build();
+  }
+
+  @Bean
+  public S3Presigner s3Presigner() {
+    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+    return S3Presigner.builder()
         .region(Region.of(region))
         .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
         .build();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,7 @@ cloud.aws.s3.bucket=overlang-dev-files-gukhee
 
 spring.servlet.multipart.max-file-size=2GB
 spring.servlet.multipart.max-request-size=2GB
+
+# Redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
## 작업 개요
Job 생성 및 조회 API를 구현하고 Redis queue 연동까지 완료

## 관련 이슈
- close #45 

## 작업 내용
- JobCreateRequest / Response DTO 구현
- JobService.createJob() 구현
- sourceType에 따른 분기 처리
  - UPLOAD: fileKey 기반 presignedUrl 생성
  - YOUTUBE: sourceUrl 사용
- Redis queue push 구현 (JobQueueProducer)
- Job 생성 API 구현 (POST /projects/{projectId}/jobs)
- Job 목록 조회 API 구현 (GET /projects/{projectId}/jobs)
- Job 상세 조회 API 구현 (GET /jobs/{jobId})
- LanguageCode enum 기반 sourceLanguage / targetLanguage 처리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
- Swagger를 통한 Job 생성 및 조회 테스트
<img width="2178" height="1009" alt="image" src="https://github.com/user-attachments/assets/bba99882-e04f-4c11-9b05-b4a20ca183a2" />
<img width="2190" height="980" alt="image" src="https://github.com/user-attachments/assets/0f770adf-410b-45d8-9293-5c09a11c018f" />
- Redis queue에 Job payload 정상 적재 확인
<img width="2490" height="286" alt="image" src="https://github.com/user-attachments/assets/6915e956-cab4-4bf9-8bdb-e7acfecb960e" />

## 기타 사항
- sourceLanguage와 targetLanguage는 동일할 수 없도록 validation 처리
- Worker 연동을 위한 Redis payload 구조 정의 완료