### PR TITLE
feat: AI파트 callback 전송 흐름 보완

### DIFF
--- a/ai/callback_smoke.py
+++ b/ai/callback_smoke.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+
+from ai.api.schemas import CallbackPayload, CurrentStage, JobStatus
+from ai.pipeline.callback_client import send_callback
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send a sample AI callback payload")
+    parser.add_argument("--job-id", type=str, default="1", help="Backend job id")
+    parser.add_argument(
+        "--status",
+        type=str,
+        default=JobStatus.RUNNING.value,
+        choices=[status.value for status in JobStatus],
+        help="Callback job status",
+    )
+    parser.add_argument(
+        "--stage",
+        type=str,
+        default=CurrentStage.OCR_TEXT_DETECTION.value,
+        choices=[stage.value for stage in CurrentStage],
+        help="Callback current stage",
+    )
+    parser.add_argument("--progress", type=float, default=55.0, help="Progress percent")
+
+    args = parser.parse_args()
+    send_callback(
+        CallbackPayload(
+            job_id=args.job_id,
+            status=JobStatus(args.status),
+            progress=args.progress,
+            current_stage=CurrentStage(args.stage),
+            segments=[],
+            ocr_items=[],
+            learning_data=None,
+            error_code=None,
+            error_message=None,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ai/pipeline/callback_client.py
+++ b/ai/pipeline/callback_client.py
@@ -19,15 +19,31 @@ def send_callback(payload: CallbackPayload) -> None:
     retry_count = int(os.getenv("CALLBACK_RETRY_COUNT", "3"))
     retry_delay_seconds = float(os.getenv("CALLBACK_RETRY_DELAY_SECONDS", "1.0"))
 
-    if not base_url or not worker_secret:
+    if not base_url:
+        logger.info(
+            "Callback skipped because BACKEND_INTERNAL_BASE_URL is not configured "
+            "(jobId=%s status=%s)",
+            payload.job_id,
+            payload.status,
+        )
+        return
+
+    if not worker_secret:
+        logger.warning(
+            "Callback skipped because WORKER_SECRET is not configured "
+            "(jobId=%s status=%s)",
+            payload.job_id,
+            payload.status,
+        )
         return
 
     callback_url = (
         f"{base_url.rstrip('/')}/api/v1/internal/jobs/{payload.job_id}/callback"
     )
+    callback_body = payload.model_dump(by_alias=True)
     request = urllib.request.Request(
         callback_url,
-        data=json.dumps(payload.model_dump(by_alias=True)).encode("utf-8"),
+        data=json.dumps(callback_body).encode("utf-8"),
         headers={
             "Content-Type": "application/json",
             "X-Worker-Secret": worker_secret,
@@ -38,10 +54,44 @@ def send_callback(payload: CallbackPayload) -> None:
     last_error = None
     for attempt in range(1, retry_count + 1):
         try:
-            with urllib.request.urlopen(request, timeout=10):
+            with urllib.request.urlopen(request, timeout=10) as response:
+                logger.info(
+                    "Callback sent: jobId=%s status=%s stage=%s httpStatus=%s "
+                    "attempt=%s/%s",
+                    payload.job_id,
+                    payload.status,
+                    payload.current_stage,
+                    response.status,
+                    attempt,
+                    retry_count,
+                )
                 return
+        except urllib.error.HTTPError as error:
+            error_body = error.read().decode("utf-8", errors="replace")
+            last_error = error
+            logger.warning(
+                "Callback HTTP error: jobId=%s status=%s httpStatus=%s "
+                "attempt=%s/%s body=%s",
+                payload.job_id,
+                payload.status,
+                error.code,
+                attempt,
+                retry_count,
+                error_body,
+            )
+            if attempt == retry_count:
+                break
+            time.sleep(retry_delay_seconds)
         except urllib.error.URLError as error:
             last_error = error
+            logger.warning(
+                "Callback request error: jobId=%s status=%s attempt=%s/%s error=%s",
+                payload.job_id,
+                payload.status,
+                attempt,
+                retry_count,
+                error,
+            )
             if attempt == retry_count:
                 break
             time.sleep(retry_delay_seconds)

--- a/ai/worker/tasks.py
+++ b/ai/worker/tasks.py
@@ -37,6 +37,7 @@ def _build_task_meta(
 
 
 def _execute_job_task(self, job_payload: dict):
+    callback_job_id = _resolve_callback_job_id(job_payload, self.request.id)
     task_progress = {
         "progress": 0.0,
         "current_stage": CurrentStage.QUEUED,
@@ -49,7 +50,11 @@ def _execute_job_task(self, job_payload: dict):
     )
 
     try:
-        logger.info("Task started: %s", self.request.id)
+        logger.info(
+            "Task started: celeryTaskId=%s callbackJobId=%s",
+            self.request.id,
+            callback_job_id,
+        )
 
         def progress_callback(
             current_stage: CurrentStage,
@@ -64,7 +69,7 @@ def _execute_job_task(self, job_payload: dict):
             )
             send_callback(
                 CallbackPayload(
-                    job_id=self.request.id,
+                    job_id=callback_job_id,
                     status=JobStatus.RUNNING,
                     progress=float(progress),
                     current_stage=current_stage,
@@ -79,13 +84,13 @@ def _execute_job_task(self, job_payload: dict):
         result = run_pipeline(
             job_payload,
             progress_callback=progress_callback,
-            job_id=self.request.id,
+            job_id=callback_job_id,
             keep_intermediate_files=True,
         )
 
         send_callback(
             CallbackPayload(
-                job_id=self.request.id,
+                job_id=callback_job_id,
                 status=JobStatus.COMPLETED,
                 progress=100.0,
                 current_stage=CurrentStage.FINALIZING,
@@ -131,7 +136,7 @@ def _execute_job_task(self, job_payload: dict):
         )
         send_callback(
             CallbackPayload(
-                job_id=self.request.id,
+                job_id=callback_job_id,
                 status=JobStatus.FAILED,
                 progress=float(task_progress["progress"]),
                 current_stage=task_progress["current_stage"],
@@ -145,6 +150,13 @@ def _execute_job_task(self, job_payload: dict):
         raise Exception(
             json.dumps({"code": error_code.value, "message": error_message})
         )
+
+
+def _resolve_callback_job_id(
+    job_payload: dict,
+    celery_task_id: str,
+) -> str | int:
+    return job_payload.get("jobId") or job_payload.get("job_id") or celery_task_id
 
 
 @celery_app.task(bind=True)


### PR DESCRIPTION
## 작업 개요
AI callback 전송 흐름을 보완했습니다.

callback `jobId`를 Celery task id가 아니라 Backend job id 기준으로 전송하도록 수정했고, callback 환경변수 누락/성공/실패/retry 로그를 보강했습니다. 또한 mock endpoint로 payload를 검증할 수 있도록 smoke script를 추가했습니다.

## 관련 이슈
- close #54 

## 작업 내용
- `job_payload["jobId"]`를 callback URL/body의 job id로 사용
- `jobId`가 없는 local/task 실행에서는 Celery task id fallback
- `BACKEND_INTERNAL_BASE_URL` 누락 시 skip 로그 추가
- `WORKER_SECRET` 누락 시 warning 로그 추가
- callback 성공 시 HTTP status 로그 추가
- HTTP error / request error retry 로그 추가
- `ai/callback_smoke.py` 추가
 
## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] callback smoke script로 payload 전송 확인
- [x] URL job id와 body jobId 일치 확인
- [x] `X-Worker-Secret` 헤더 전송 확인
- [ ] 실제 Backend callback API와 end-to-end 검증
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항