### PR TITLE
feat: 콜백 결과 데이터 저장 로직 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -1,0 +1,28 @@
+package com.overlang.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.*;
+import com.overlang.api.dto.job.JobCallbackRequest;
+import com.overlang.api.dto.job.JobCallbackResponse;
+import com.overlang.domain.job.service.JobService;
+import com.overlang.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/jobs")
+public class InternalJobController {
+
+    private final JobService jobService;
+
+    @Operation(summary = "AI 작업 콜백 처리", description = "AI Worker가 작업 상태(RUNNING, COMPLETED, FAILED) 및 결과 데이터를 BE로 전달하는 내부 API입니다.")
+    @PostMapping("/{jobId}/callback")
+    public ApiResponse<JobCallbackResponse> handleCallback(
+            @PathVariable Long jobId,
+            @RequestBody JobCallbackRequest request) {
+
+        JobCallbackResponse response = jobService.handleCallback(jobId, request);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -5,6 +5,8 @@ import com.overlang.api.dto.job.JobCallbackResponse;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +24,52 @@ public class InternalJobController {
   public ApiResponse<JobCallbackResponse> handleCallback(
       @PathVariable Long jobId,
       @RequestHeader("X-Worker-Secret") String requestWorkerSecret,
-      @RequestBody JobCallbackRequest request) {
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples =
+                          @ExampleObject(
+                              name = "콜백 예시",
+                              value =
+                                  """
+                {
+                  "jobId": 2,
+                  "status": "COMPLETED",
+                  "progress": 100,
+                  "currentStage": "FINALIZING",
+                  "segments": [
+                    {
+                      "seq": 1,
+                      "startTime": 0.0,
+                      "endTime": 2.0,
+                      "text": "Hello",
+                      "translatedText": "안녕",
+                      "languageCode": "en"
+                    }
+                  ],
+                  "ocrItems": [
+                    {
+                      "startTime": 1.0,
+                      "endTime": 2.0,
+                      "originText": "EXIT",
+                      "translatedText": "출구",
+                      "boundingBox": {
+                        "x": 0.1,
+                        "y": 0.2,
+                        "w": 0.3,
+                        "h": 0.4
+                      },
+                      "confidence": 0.95
+                    }
+                  ],
+                  "learningData": null,
+                  "errorCode": null,
+                  "errorMessage": null
+                }
+                """)))
+          @org.springframework.web.bind.annotation.RequestBody
+          JobCallbackRequest request) {
 
     JobCallbackResponse response = jobService.handleCallback(jobId, requestWorkerSecret, request);
 

--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -1,28 +1,31 @@
 package com.overlang.api.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.web.bind.annotation.*;
 import com.overlang.api.dto.job.JobCallbackRequest;
 import com.overlang.api.dto.job.JobCallbackResponse;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/internal/jobs")
 public class InternalJobController {
 
-    private final JobService jobService;
+  private final JobService jobService;
 
-    @Operation(summary = "AI 작업 콜백 처리", description = "AI Worker가 작업 상태(RUNNING, COMPLETED, FAILED) 및 결과 데이터를 BE로 전달하는 내부 API입니다.")
-    @PostMapping("/{jobId}/callback")
-    public ApiResponse<JobCallbackResponse> handleCallback(
-            @PathVariable Long jobId,
-            @RequestBody JobCallbackRequest request) {
+  @Operation(
+      summary = "AI 작업 콜백 처리",
+      description = "AI Worker가 작업 상태(RUNNING, COMPLETED, FAILED) 및 결과 데이터를 BE로 전달하는 내부 API입니다.")
+  @PostMapping("/{jobId}/callback")
+  public ApiResponse<JobCallbackResponse> handleCallback(
+      @PathVariable Long jobId,
+      @RequestHeader("X-Worker-Secret") String requestWorkerSecret,
+      @RequestBody JobCallbackRequest request) {
 
-        JobCallbackResponse response = jobService.handleCallback(jobId, request);
+    JobCallbackResponse response = jobService.handleCallback(jobId, requestWorkerSecret, request);
 
-        return ApiResponse.success(response);
-    }
+    return ApiResponse.success(response);
+  }
 }

--- a/backend/src/main/java/com/overlang/api/dto/job/BoundingBoxRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/BoundingBoxRequest.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.job;
+
+public record BoundingBoxRequest(Double x, Double y, Double w, Double h) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
@@ -1,0 +1,8 @@
+package com.overlang.api.dto.job;
+
+public record CallbackOcrItemRequest(
+    Double startTime,
+    Double endTime,
+    String originText,
+    String translatedText,
+    BoundingBoxRequest boundingBox) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
@@ -5,4 +5,5 @@ public record CallbackOcrItemRequest(
     Double endTime,
     String originText,
     String translatedText,
-    BoundingBoxRequest boundingBox) {}
+    BoundingBoxRequest boundingBox,
+    Double confidence) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackSegmentRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackSegmentRequest.java
@@ -1,0 +1,9 @@
+package com.overlang.api.dto.job;
+
+public record CallbackSegmentRequest(
+    Integer seq,
+    Double startTime,
+    Double endTime,
+    String text,
+    String translatedText,
+    String languageCode) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCallbackRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCallbackRequest.java
@@ -1,0 +1,16 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.job.entity.CurrentStage;
+import com.overlang.domain.job.entity.JobStatus;
+import java.util.List;
+
+public record JobCallbackRequest(
+    Long jobId,
+    JobStatus status,
+    Integer progress,
+    CurrentStage currentStage,
+    List<CallbackSegmentRequest> segments,
+    List<CallbackOcrItemRequest> ocrItems,
+    Object learningData,
+    String errorCode,
+    String errorMessage) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCallbackResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCallbackResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.job;
+
+public record JobCallbackResponse(Long jobId, Boolean updated) {}

--- a/backend/src/main/java/com/overlang/domain/job/entity/Job.java
+++ b/backend/src/main/java/com/overlang/domain/job/entity/Job.java
@@ -75,25 +75,28 @@ public class Job extends BaseTimeEntity { // 시간 자동 기록
     this.useUserApiKey = useUserApiKey != null && useUserApiKey;
   }
 
-  public void markRunning(CurrentStage stage, int progress) {
+  public void updateRunning(Integer progress, CurrentStage currentStage) {
     this.status = JobStatus.RUNNING;
-    this.currentStage = stage;
     this.progress = progress;
+    this.currentStage = currentStage;
     this.errorCode = null;
     this.errorMessage = null;
   }
 
-  public void markCompleted() {
+  public void complete(
+      Integer progress, CurrentStage currentStage, String errorCode, String errorMessage) {
     this.status = JobStatus.COMPLETED;
-    this.currentStage = CurrentStage.FINALIZING;
-    this.progress = 100;
-    this.errorCode = null;
-    this.errorMessage = null;
+    this.progress = progress;
+    this.currentStage = currentStage;
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
   }
 
-  public void markFailed(String errorCode, String errorMessage) {
-    this.currentStage = CurrentStage.FINALIZING;
+  public void fail(
+      Integer progress, CurrentStage currentStage, String errorCode, String errorMessage) {
     this.status = JobStatus.FAILED;
+    this.progress = progress;
+    this.currentStage = currentStage;
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }

--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
@@ -8,6 +8,7 @@ import com.overlang.domain.project.entity.SourceType;
 public record JobQueuePayload(
     Long jobId,
     Long projectId,
+    Long memberId,
     SourceType sourceType,
     String sourceUrl,
     String fileKey,

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -17,6 +17,7 @@ import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,9 @@ public class JobService {
   private final JobRepository jobRepository;
   private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
+
+  @Value("${worker.secret}")
+  private String workerSecret;
 
   @Transactional
   public JobCreateResponse createJob(Long projectId, Long memberId, JobCreateRequest request) {
@@ -135,8 +139,16 @@ public class JobService {
     return JobDetailResponse.from(job);
   }
 
+  private void validateWorkerSecret(String requestWorkerSecret) {
+    if (requestWorkerSecret == null || !workerSecret.equals(requestWorkerSecret)) {
+      throw new IllegalArgumentException("Worker Secret이 일치하지 않습니다.");
+    }
+  }
+
   @Transactional
-  public JobCallbackResponse handleCallback(Long pathJobId, JobCallbackRequest request) {
+  public JobCallbackResponse handleCallback(
+      Long pathJobId, String requestWorkerSecret, JobCallbackRequest request) {
+    validateWorkerSecret(requestWorkerSecret);
     validateCallbackJobId(pathJobId, request.jobId());
 
     Job job = findJobById(pathJobId);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -1,5 +1,7 @@
 package com.overlang.domain.job.service;
 
+import com.overlang.api.dto.job.JobCallbackRequest;
+import com.overlang.api.dto.job.JobCallbackResponse;
 import com.overlang.api.dto.job.JobCreateRequest;
 import com.overlang.api.dto.job.JobCreateResponse;
 import com.overlang.api.dto.job.JobDetailResponse;
@@ -57,20 +59,18 @@ public class JobService {
   }
 
   private void validateJobCreateRequest(JobCreateRequest request) {
-    if (request.jobType() == null) {
-      throw new IllegalArgumentException("jobType은 필수입니다.");
-    }
-
-    if (request.sourceLanguage() == null) {
-      throw new IllegalArgumentException("sourceLanguage는 필수입니다.");
-    }
-
-    if (request.targetLanguage() == null) {
-      throw new IllegalArgumentException("targetLanguage는 필수입니다.");
-    }
+    requireNonNull(request.jobType(), "jobType");
+    requireNonNull(request.sourceLanguage(), "sourceLanguage");
+    requireNonNull(request.targetLanguage(), "targetLanguage");
 
     if (request.sourceLanguage() == request.targetLanguage()) {
       throw new IllegalArgumentException("sourceLanguage와 targetLanguage는 같을 수 없습니다.");
+    }
+  }
+
+  private void requireNonNull(Object value, String fieldName) {
+    if (value == null) {
+      throw new IllegalArgumentException(fieldName + "은(는) 필수입니다.");
     }
   }
 
@@ -133,5 +133,52 @@ public class JobService {
             .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
 
     return JobDetailResponse.from(job);
+  }
+
+  @Transactional
+  public JobCallbackResponse handleCallback(Long pathJobId, JobCallbackRequest request) {
+    validateCallbackJobId(pathJobId, request.jobId());
+
+    Job job = findJobById(pathJobId);
+
+    switch (request.status()) {
+      case RUNNING -> handleRunningCallback(job, request);
+      case COMPLETED -> handleCompletedCallback(job, request);
+      case FAILED -> handleFailedCallback(job, request);
+      default -> throw new IllegalArgumentException("지원하지 않는 작업 상태입니다.");
+    }
+
+    return new JobCallbackResponse(job.getId(), true);
+  }
+
+  private void validateCallbackJobId(Long pathJobId, Long bodyJobId) {
+    if (!pathJobId.equals(bodyJobId)) {
+      throw new IllegalArgumentException("URI jobId와 Body jobId가 일치하지 않습니다.");
+    }
+  }
+
+  private Job findJobById(Long jobId) {
+    return jobRepository
+        .findById(jobId)
+        .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+  }
+
+  private void handleRunningCallback(Job job, JobCallbackRequest request) {
+    job.updateRunning(request.progress(), request.currentStage());
+    job.getProject().markProcessing();
+  }
+
+  private void handleCompletedCallback(Job job, JobCallbackRequest request) {
+    job.complete(
+        request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
+
+    job.getProject().markCompleted();
+  }
+
+  private void handleFailedCallback(Job job, JobCallbackRequest request) {
+    job.fail(
+        request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
+
+    job.getProject().markFailed();
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -11,10 +11,14 @@ import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.queue.JobQueuePayload;
 import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.ocr.entity.OcrItem;
+import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.repository.SegmentRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +33,8 @@ public class JobService {
   private final JobRepository jobRepository;
   private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
+  private final SegmentRepository segmentRepository;
+  private final OcrItemRepository ocrItemRepository;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -184,6 +190,9 @@ public class JobService {
     job.complete(
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
+    saveSegments(job, request);
+    saveOcrItems(job, request);
+
     job.getProject().markCompleted();
   }
 
@@ -192,5 +201,48 @@ public class JobService {
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
     job.getProject().markFailed();
+  }
+
+  private void saveSegments(Job job, JobCallbackRequest request) {
+    if (request.segments() == null) return;
+
+    List<Segment> segments =
+        request.segments().stream()
+            .map(
+                s ->
+                    new Segment(
+                        job,
+                        s.startTime(),
+                        s.endTime(),
+                        s.seq(),
+                        s.text(),
+                        s.translatedText(),
+                        s.languageCode()))
+            .toList();
+
+    segmentRepository.saveAll(segments);
+  }
+
+  private void saveOcrItems(Job job, JobCallbackRequest request) {
+    if (request.ocrItems() == null) return;
+
+    List<OcrItem> ocrItems =
+        request.ocrItems().stream()
+            .map(
+                o ->
+                    new OcrItem(
+                        job,
+                        o.startTime(),
+                        o.endTime(),
+                        o.originText(),
+                        o.translatedText(),
+                        o.boundingBox().x(),
+                        o.boundingBox().y(),
+                        o.boundingBox().w(),
+                        o.boundingBox().h(),
+                        o.confidence()))
+            .toList();
+
+    ocrItemRepository.saveAll(ocrItems);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -84,6 +84,7 @@ public class JobService {
         yield new JobQueuePayload(
             job.getId(),
             project.getId(),
+            project.getMember().getId(),
             sourceType,
             null,
             project.getFileKey(),
@@ -99,6 +100,7 @@ public class JobService {
           new JobQueuePayload(
               job.getId(),
               project.getId(),
+              project.getMember().getId(),
               sourceType,
               project.getSourceUrl(),
               null,

--- a/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
@@ -1,0 +1,6 @@
+package com.overlang.domain.ocr.repository;
+
+import com.overlang.domain.ocr.entity.OcrItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OcrItemRepository extends JpaRepository<OcrItem, Long> {}

--- a/backend/src/main/java/com/overlang/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/overlang/domain/project/entity/Project.java
@@ -97,4 +97,16 @@ public class Project extends BaseTimeEntity {
   public void updateTitle(String title) {
     this.title = title;
   } // 프로젝트 제목 수정
+
+  public void markProcessing() {
+    this.status = ProjectStatus.PROCESSING;
+  }
+
+  public void markCompleted() {
+    this.status = ProjectStatus.COMPLETED;
+  }
+
+  public void markFailed() {
+    this.status = ProjectStatus.FAILED;
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
@@ -1,0 +1,6 @@
+package com.overlang.domain.segment.repository;
+
+import com.overlang.domain.segment.entity.Segment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SegmentRepository extends JpaRepository<Segment, Long> {}

--- a/backend/src/main/java/com/overlang/global/config/WebConfig.java
+++ b/backend/src/main/java/com/overlang/global/config/WebConfig.java
@@ -30,6 +30,10 @@ public class WebConfig implements WebMvcConfigurer {
         .addInterceptor(authInterceptor)
         .addPathPatterns("/api/v1/**")
         .excludePathPatterns(
-            "/api/v1/auth/firebase", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**");
+            "/api/v1/auth/firebase",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/api/v1/internal/**");
   }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,3 +30,5 @@ spring.servlet.multipart.max-request-size=2GB
 # Redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+
+worker.secret=overlang-worker-secret


### PR DESCRIPTION
## 작업 개요
AI Worker로부터 전달되는 콜백 데이터를 처리하는 API를 구현
작업 상태 업데이트 및 결과 데이터(segments, ocrItems)를 DB에 저장하도록 구현
## 관련 이슈
- close #47

## 작업 내용
- Internal Job Callback API 구현 (POST /api/v1/internal/jobs/{jobId}/callback)
- WorkerSecret 기반 내부 인증 로직 구현
- Job 상태 업데이트 처리 (RUNNING / COMPLETED / FAILED)
- Project 상태 동기화 처리 (PROCESSING / COMPLETED / FAILED)
- 부분 성공 처리 로직 구현 (errorCode, errorMessage 유지)
- Segment, OCR 결과 데이터 저장 로직 구현
## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="2296" height="480" alt="image" src="https://github.com/user-attachments/assets/d374a45b-6e66-43d7-ae60-ab454ec7d033" />

## 기타 사항
- learningData 구조는 추후 Worker와 협의 후 별도 구현 예정
- 콜백 API는 내부 API로 Firebase 인증 대신 WorkerSecret 인증 사용