### PR TITLE
feat: AI 결과 조회 API 및 권한 검증 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/JobResultController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobResultController.java
@@ -1,0 +1,32 @@
+package com.overlang.api.controller;
+
+import com.overlang.api.dto.ocr.OcrItemResponse;
+import com.overlang.api.dto.segment.SegmentResponse;
+import com.overlang.domain.job.service.JobResultService;
+import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/jobs")
+public class JobResultController {
+
+  private final JobResultService jobResultService;
+
+  @Operation(summary = "세그먼트 조회", description = "특정 Job의 STT 세그먼트를 조회합니다.")
+  @GetMapping("/{jobId}/segments")
+  public ApiResponse<List<SegmentResponse>> getSegments(@PathVariable Long jobId) {
+    List<SegmentResponse> result = jobResultService.getSegments(jobId);
+    return ApiResponse.success(result);
+  }
+
+  @Operation(summary = "OCR 결과 조회", description = "특정 Job의 OCR 결과를 조회합니다.")
+  @GetMapping("/{jobId}/ocr-items")
+  public ApiResponse<List<OcrItemResponse>> getOcrItems(@PathVariable Long jobId) {
+    List<OcrItemResponse> result = jobResultService.getOcrItems(jobId);
+    return ApiResponse.success(result);
+  }
+}

--- a/backend/src/main/java/com/overlang/api/controller/JobResultController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobResultController.java
@@ -3,6 +3,7 @@ package com.overlang.api.controller;
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.domain.job.service.JobResultService;
+import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
@@ -18,15 +19,17 @@ public class JobResultController {
 
   @Operation(summary = "세그먼트 조회", description = "특정 Job의 STT 세그먼트를 조회합니다.")
   @GetMapping("/{jobId}/segments")
-  public ApiResponse<List<SegmentResponse>> getSegments(@PathVariable Long jobId) {
-    List<SegmentResponse> result = jobResultService.getSegments(jobId);
+  public ApiResponse<List<SegmentResponse>> getSegments(
+      @PathVariable Long jobId, @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId) {
+    List<SegmentResponse> result = jobResultService.getSegments(jobId, memberId);
     return ApiResponse.success(result);
   }
 
   @Operation(summary = "OCR 결과 조회", description = "특정 Job의 OCR 결과를 조회합니다.")
   @GetMapping("/{jobId}/ocr-items")
-  public ApiResponse<List<OcrItemResponse>> getOcrItems(@PathVariable Long jobId) {
-    List<OcrItemResponse> result = jobResultService.getOcrItems(jobId);
+  public ApiResponse<List<OcrItemResponse>> getOcrItems(
+      @PathVariable Long jobId, @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId) {
+    List<OcrItemResponse> result = jobResultService.getOcrItems(jobId, memberId);
     return ApiResponse.success(result);
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/ocr/BoundingBoxResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/BoundingBoxResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record BoundingBoxResponse(Double x, Double y, Double w, Double h) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
@@ -1,0 +1,26 @@
+package com.overlang.api.dto.ocr;
+
+import com.overlang.domain.ocr.entity.OcrItem;
+
+public record OcrItemResponse(
+    Long ocrItemId,
+    Long jobId,
+    Double startTime,
+    Double endTime,
+    String originText,
+    String translatedText,
+    BoundingBoxResponse boundingBox,
+    Double confidence) {
+
+  public static OcrItemResponse from(OcrItem ocrItem) {
+    return new OcrItemResponse(
+        ocrItem.getId(),
+        ocrItem.getJob().getId(),
+        ocrItem.getStartTime(),
+        ocrItem.getEndTime(),
+        ocrItem.getOriginText(),
+        ocrItem.getTranslatedText(),
+        new BoundingBoxResponse(ocrItem.getX(), ocrItem.getY(), ocrItem.getW(), ocrItem.getH()),
+        ocrItem.getConfidence());
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
@@ -1,0 +1,26 @@
+package com.overlang.api.dto.segment;
+
+import com.overlang.domain.segment.entity.Segment;
+
+public record SegmentResponse(
+    Long segmentId,
+    Long jobId,
+    Integer seq,
+    Double startTime,
+    Double endTime,
+    String text,
+    String translatedText,
+    String languageCode) {
+
+  public static SegmentResponse from(Segment segment) {
+    return new SegmentResponse(
+        segment.getId(),
+        segment.getJob().getId(),
+        segment.getSeq(),
+        segment.getStartTime(),
+        segment.getEndTime(),
+        segment.getText(),
+        segment.getTranslatedText(),
+        segment.getLanguageCode());
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -9,4 +9,6 @@ public interface JobRepository extends JpaRepository<Job, Long> {
   List<Job> findByProjectIdOrderByCreatedAtDesc(Long projectId);
 
   Optional<Job> findByIdAndProjectMemberId(Long jobId, Long memberId);
+
+  boolean existsByIdAndProjectMemberId(Long jobId, Long memberId);
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -2,6 +2,7 @@ package com.overlang.domain.job.service;
 
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
+import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import java.util.List;
@@ -15,18 +16,27 @@ public class JobResultService {
 
   private final SegmentRepository segmentRepository;
   private final OcrItemRepository ocrItemRepository;
+  private final JobRepository jobRepository;
 
   @Transactional(readOnly = true)
-  public List<SegmentResponse> getSegments(Long jobId) {
+  public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
+    validateJobOwner(jobId, memberId);
     return segmentRepository.findByJobIdOrderBySeqAsc(jobId).stream()
         .map(SegmentResponse::from)
         .toList();
   }
 
   @Transactional(readOnly = true)
-  public List<OcrItemResponse> getOcrItems(Long jobId) {
+  public List<OcrItemResponse> getOcrItems(Long jobId, Long memberId) {
+    validateJobOwner(jobId, memberId);
     return ocrItemRepository.findByJobIdOrderByStartTimeAsc(jobId).stream()
         .map(OcrItemResponse::from)
         .toList();
+  }
+
+  private void validateJobOwner(Long jobId, Long memberId) {
+    if (!jobRepository.existsByIdAndProjectMemberId(jobId, memberId)) {
+      throw new IllegalArgumentException("작업을 찾을 수 없습니다.");
+    }
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,0 +1,32 @@
+package com.overlang.domain.job.service;
+
+import com.overlang.api.dto.ocr.OcrItemResponse;
+import com.overlang.api.dto.segment.SegmentResponse;
+import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.segment.repository.SegmentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JobResultService {
+
+  private final SegmentRepository segmentRepository;
+  private final OcrItemRepository ocrItemRepository;
+
+  @Transactional(readOnly = true)
+  public List<SegmentResponse> getSegments(Long jobId) {
+    return segmentRepository.findByJobIdOrderBySeqAsc(jobId).stream()
+        .map(SegmentResponse::from)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<OcrItemResponse> getOcrItems(Long jobId) {
+    return ocrItemRepository.findByJobIdOrderByStartTimeAsc(jobId).stream()
+        .map(OcrItemResponse::from)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -190,10 +190,16 @@ public class JobService {
     job.complete(
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
+    deletePreviousResults(job.getId());
     saveSegments(job, request);
     saveOcrItems(job, request);
 
     job.getProject().markCompleted();
+  }
+
+  private void deletePreviousResults(Long jobId) {
+    segmentRepository.deleteByJobId(jobId);
+    ocrItemRepository.deleteByJobId(jobId);
   }
 
   private void handleFailedCallback(Job job, JobCallbackRequest request) {

--- a/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
@@ -1,6 +1,11 @@
 package com.overlang.domain.ocr.repository;
 
 import com.overlang.domain.ocr.entity.OcrItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OcrItemRepository extends JpaRepository<OcrItem, Long> {}
+public interface OcrItemRepository extends JpaRepository<OcrItem, Long> {
+  List<OcrItem> findByJobIdOrderByStartTimeAsc(Long jobId);
+
+  void deleteByJobId(Long jobId);
+}

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
@@ -1,6 +1,11 @@
 package com.overlang.domain.segment.repository;
 
 import com.overlang.domain.segment.entity.Segment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SegmentRepository extends JpaRepository<Segment, Long> {}
+public interface SegmentRepository extends JpaRepository<Segment, Long> {
+  List<Segment> findByJobIdOrderBySeqAsc(Long jobId);
+
+  void deleteByJobId(Long jobId);
+}


### PR DESCRIPTION
## 작업 개요
AI 분석 결과(segments, OCR)를 조회할 수 있는 API를 구현
로그인 사용자 기준으로 본인 Job 결과만 조회 가능하도록 구현

## 관련 이슈
- close #58 

## 작업 내용
- Segment 조회 API 구현 (`GET /api/v1/jobs/{jobId}/segments`)
- OCR 결과 조회 API 구현 (`GET /api/v1/jobs/{jobId}/ocr-items`)
- JobResultService를 통해 결과 조회 로직 통합 구현
- SegmentController / OcrItemController 대신 JobResultController로 통합 구현
- Job 소유자 검증 로직 추가 (memberId 기반)
- 동일 Job에 대한 결과 중복 저장 방지 로직 구현 (기존 데이터 삭제 후 재저장)

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항
- 결과 조회 API는 Firebase 인증 기반으로 동작하며, 본인 프로젝트의 Job 결과만 조회 가능
- Callback API에서 동일 Job에 대한 결과 재수신 시 기존 데이터 삭제 후 재저장하도록 처리하여 중복 저장 방지