### PR TITLE
feat: 프로젝트 영상 재생용 presigned url API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/ProjectController.java
+++ b/backend/src/main/java/com/overlang/api/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.overlang.api.controller;
 
+import com.overlang.api.dto.file.PresignedUrlResponse;
 import com.overlang.api.dto.project.ProjectCreateRequest;
 import com.overlang.api.dto.project.ProjectCreateResponse;
 import com.overlang.api.dto.project.ProjectDetailResponse;
@@ -13,8 +14,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,5 +51,16 @@ public class ProjectController {
 
     ProjectDetailResponse response = projectService.getProject(memberId, projectId);
     return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "프로젝트 영상 재생용 Presigned URL 발급")
+  @GetMapping("/{projectId}/video-url")
+  public ApiResponse<PresignedUrlResponse> getVideoUrl(
+      @PathVariable Long projectId, HttpServletRequest httpServletRequest) {
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    String presignedUrl = projectService.getVideoPresignedUrl(memberId, projectId);
+
+    return ApiResponse.success(new PresignedUrlResponse(presignedUrl));
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/file/PresignedUrlResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/file/PresignedUrlResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.file;
+
+public record PresignedUrlResponse(String presignedUrl) {}

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import com.overlang.api.dto.project.ProjectCreateRequest;
 import com.overlang.api.dto.project.ProjectCreateResponse;
 import com.overlang.api.dto.project.ProjectDetailResponse;
 import com.overlang.api.dto.project.ProjectResponse;
+import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
 import com.overlang.domain.project.entity.Project;
@@ -20,6 +21,7 @@ public class ProjectService {
 
   private final ProjectRepository projectRepository;
   private final MemberRepository memberRepository;
+  private final S3UploadService s3UploadService;
 
   public ProjectCreateResponse createProject(Long memberId, ProjectCreateRequest request) {
     Member member =
@@ -82,5 +84,19 @@ public class ProjectService {
         project.getFileUrl(),
         project.getStatus(),
         project.getCreatedAt());
+  }
+
+  @Transactional(readOnly = true)
+  public String getVideoPresignedUrl(Long memberId, Long projectId) {
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+
+    if (project.getFileKey() == null || project.getFileKey().isBlank()) {
+      throw new IllegalArgumentException("업로드된 영상이 없습니다.");
+    }
+
+    return s3UploadService.generatePresignedGetUrl(project.getFileKey());
   }
 }


### PR DESCRIPTION
## 작업 개요
- Private S3 환경에서 프로젝트 영상 재생이 가능하도록 Presigned URL 발급 API를 구현
## 관련 이슈
- close #66 

## 작업 내용
- `GET /api/v1/projects/{projectId}/video-url` API 구현
- 프로젝트 소유자 검증 후 Presigned URL 발급하도록 구현
- Swagger 테스트 및 브라우저 영상 재생 확인 완료

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
- Swagger 및 브라우저에서 Presigned URL 기반 영상 재생 확인 완료
<img width="1392" height="322" alt="image" src="https://github.com/user-attachments/assets/8cdc344e-b765-465e-b708-77a34afc4356" />
<img width="1931" height="257" alt="image" src="https://github.com/user-attachments/assets/6415848b-37db-4a98-8fa4-20a7f4103f7a" />


## 기타 사항
- S3 버킷은 private 상태 유지