### PR TITLE
feat: 유튜브 분석 결과 캐시 기능 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCreateResponse.java
@@ -19,11 +19,16 @@ public record JobCreateResponse(
     LanguageCode targetLanguage,
     TranslationProvider translationProvider,
     Boolean useUserApiKey,
+    Boolean cached,
     String errorCode,
     String errorMessage,
     Instant createdAt) {
 
   public static JobCreateResponse from(Job job) {
+    return from(job, false);
+  }
+
+  public static JobCreateResponse from(Job job, boolean cached) {
     return new JobCreateResponse(
         job.getId(),
         job.getProject().getId(),
@@ -35,6 +40,7 @@ public record JobCreateResponse(
         job.getTargetLanguage(),
         job.getTranslationProvider(),
         job.getUseUserApiKey(),
+        cached,
         job.getErrorCode(),
         job.getErrorMessage(),
         job.getCreatedAt());

--- a/backend/src/main/java/com/overlang/domain/cache/service/ResultCacheService.java
+++ b/backend/src/main/java/com/overlang/domain/cache/service/ResultCacheService.java
@@ -1,0 +1,45 @@
+package com.overlang.domain.cache.service;
+
+import com.overlang.api.dto.job.JobCreateRequest;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.entity.SourceType;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResultCacheService {
+
+  private final JobRepository jobRepository;
+
+  public Optional<Job> findReusableJob(Project project, JobCreateRequest request) {
+    if (project.getSourceType() == SourceType.YOUTUBE) {
+      return findReusableYoutubeJob(project, request);
+    }
+
+    return Optional.empty();
+  }
+
+  private Optional<Job> findReusableYoutubeJob(Project project, JobCreateRequest request) {
+    if (project.getYoutubeVideoId() == null || project.getYoutubeVideoId().isBlank()) {
+      return Optional.empty();
+    }
+
+    return jobRepository
+        .findReusableYoutubeJobs(
+            SourceType.YOUTUBE,
+            project.getYoutubeVideoId(),
+            JobStatus.COMPLETED,
+            request.sourceLanguage(),
+            request.targetLanguage(),
+            request.translationProvider(),
+            PageRequest.of(0, 1))
+        .stream()
+        .findFirst();
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
+++ b/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
@@ -1,0 +1,69 @@
+package com.overlang.domain.cache.service;
+
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.ocr.entity.OcrItem;
+import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.repository.SegmentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResultCopyService {
+
+  private final SegmentRepository segmentRepository;
+  private final OcrItemRepository ocrItemRepository;
+
+  public void copyResults(Job sourceJob, Job targetJob) {
+    copySegments(sourceJob, targetJob);
+    copyOcrItems(sourceJob, targetJob);
+  }
+
+  private void copySegments(Job sourceJob, Job targetJob) {
+
+    List<Segment> sourceSegments = segmentRepository.findByJobIdOrderBySeqAsc(sourceJob.getId());
+
+    List<Segment> copiedSegments =
+        sourceSegments.stream()
+            .map(
+                segment ->
+                    new Segment(
+                        targetJob,
+                        segment.getStartTime(),
+                        segment.getEndTime(),
+                        segment.getSeq(),
+                        segment.getText(),
+                        segment.getTranslatedText(),
+                        segment.getLanguageCode()))
+            .toList();
+
+    segmentRepository.saveAll(copiedSegments);
+  }
+
+  private void copyOcrItems(Job sourceJob, Job targetJob) {
+
+    List<OcrItem> sourceOcrItems =
+        ocrItemRepository.findByJobIdOrderByStartTimeAsc(sourceJob.getId());
+
+    List<OcrItem> copiedOcrItems =
+        sourceOcrItems.stream()
+            .map(
+                item ->
+                    new OcrItem(
+                        targetJob,
+                        item.getStartTime(),
+                        item.getEndTime(),
+                        item.getOriginText(),
+                        item.getTranslatedText(),
+                        item.getX(),
+                        item.getY(),
+                        item.getW(),
+                        item.getH(),
+                        item.getConfidence()))
+            .toList();
+
+    ocrItemRepository.saveAll(copiedOcrItems);
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -1,9 +1,16 @@
 package com.overlang.domain.job.repository;
 
+import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.entity.TranslationProvider;
+import com.overlang.domain.project.entity.SourceType;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JobRepository extends JpaRepository<Job, Long> {
   List<Job> findByProjectIdOrderByCreatedAtDesc(Long projectId);
@@ -11,4 +18,26 @@ public interface JobRepository extends JpaRepository<Job, Long> {
   Optional<Job> findByIdAndProjectMemberId(Long jobId, Long memberId);
 
   boolean existsByIdAndProjectMemberId(Long jobId, Long memberId);
+
+  @Query(
+      """
+      SELECT j
+      FROM Job j
+      JOIN j.project p
+      WHERE p.sourceType = :sourceType
+        AND p.youtubeVideoId = :youtubeVideoId
+        AND j.status = :status
+        AND j.sourceLanguage = :sourceLanguage
+        AND j.targetLanguage = :targetLanguage
+        AND j.translationProvider = :translationProvider
+      ORDER BY j.createdAt DESC
+      """)
+  List<Job> findReusableYoutubeJobs(
+      @Param("sourceType") SourceType sourceType,
+      @Param("youtubeVideoId") String youtubeVideoId,
+      @Param("status") JobStatus status,
+      @Param("sourceLanguage") LanguageCode sourceLanguage,
+      @Param("targetLanguage") LanguageCode targetLanguage,
+      @Param("translationProvider") TranslationProvider translationProvider,
+      Pageable pageable);
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -6,7 +6,10 @@ import com.overlang.api.dto.job.JobCreateRequest;
 import com.overlang.api.dto.job.JobCreateResponse;
 import com.overlang.api.dto.job.JobDetailResponse;
 import com.overlang.api.dto.job.JobResponse;
+import com.overlang.domain.cache.service.ResultCacheService;
+import com.overlang.domain.cache.service.ResultCopyService;
 import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.domain.job.entity.CurrentStage;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.queue.JobQueuePayload;
 import com.overlang.domain.job.queue.JobQueueProducer;
@@ -35,6 +38,8 @@ public class JobService {
   private final JobQueueProducer jobQueueProducer;
   private final SegmentRepository segmentRepository;
   private final OcrItemRepository ocrItemRepository;
+  private final ResultCacheService resultCacheService;
+  private final ResultCopyService resultCopyService;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -59,13 +64,22 @@ public class JobService {
 
     Job savedJob = jobRepository.save(job);
 
+    var reusableJob = resultCacheService.findReusableJob(project, request);
+
+    if (reusableJob.isPresent()) {
+      resultCopyService.copyResults(reusableJob.get(), savedJob);
+      savedJob.complete(100, CurrentStage.FINALIZING, null, null);
+      project.markCompleted();
+
+      return JobCreateResponse.from(savedJob, true);
+    }
+
     project.updateStatus(ProjectStatus.PROCESSING);
 
     JobQueuePayload payload = createQueuePayload(project, savedJob);
-
     jobQueueProducer.enqueue(payload);
 
-    return JobCreateResponse.from(savedJob);
+    return JobCreateResponse.from(savedJob, false);
   }
 
   private void validateJobCreateRequest(JobCreateRequest request) {

--- a/backend/src/main/java/com/overlang/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/overlang/domain/project/entity/Project.java
@@ -29,6 +29,9 @@ public class Project extends BaseTimeEntity {
   @Column(name = "source_url", length = 1024) // 유튜브 URL
   private String sourceUrl;
 
+  @Column(name = "youtube_video_id", length = 50)
+  private String youtubeVideoId;
+
   @Column(name = "file_url", length = 1024) // S3 URL
   private String fileUrl;
 
@@ -44,6 +47,7 @@ public class Project extends BaseTimeEntity {
       String title,
       SourceType sourceType,
       String sourceUrl,
+      String youtubeVideoId,
       String fileUrl,
       String fileKey) {
     validateSource(sourceType, sourceUrl, fileUrl, fileKey);
@@ -51,6 +55,7 @@ public class Project extends BaseTimeEntity {
     this.title = title;
     this.sourceType = sourceType;
     this.sourceUrl = sourceUrl;
+    this.youtubeVideoId = youtubeVideoId;
     this.fileUrl = fileUrl;
     this.fileKey = fileKey;
     this.status = ProjectStatus.CREATED;

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -8,7 +8,9 @@ import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
 import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.global.util.YoutubeUrlUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,12 +31,19 @@ public class ProjectService {
             .findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
+    String youtubeVideoId = null;
+
+    if (request.sourceType() == SourceType.YOUTUBE) {
+      youtubeVideoId = YoutubeUrlUtils.extractVideoId(request.sourceUrl());
+    }
+
     Project project =
         new Project(
             member,
             request.title(),
             request.sourceType(),
             request.sourceUrl(),
+            youtubeVideoId,
             request.fileUrl(),
             request.fileKey());
 

--- a/backend/src/main/java/com/overlang/global/util/YoutubeUrlUtils.java
+++ b/backend/src/main/java/com/overlang/global/util/YoutubeUrlUtils.java
@@ -1,0 +1,78 @@
+package com.overlang.global.util;
+
+import java.net.URI;
+
+public final class YoutubeUrlUtils {
+
+  private YoutubeUrlUtils() {}
+
+  public static String extractVideoId(String url) {
+    if (url == null || url.isBlank()) {
+      throw new IllegalArgumentException("YouTube URL이 비어 있습니다.");
+    }
+
+    URI uri = URI.create(url);
+    String host = uri.getHost();
+    String path = uri.getPath();
+    String query = uri.getQuery();
+
+    if (host == null) {
+      throw new IllegalArgumentException("올바른 YouTube URL이 아닙니다.");
+    }
+
+    if (host.contains("youtu.be")) {
+      return extractFromShortUrl(path);
+    }
+
+    if (host.contains("youtube.com")) {
+      String videoId = extractFromQuery(query);
+      if (videoId != null) {
+        return videoId;
+      }
+
+      return extractFromPath(path);
+    }
+
+    throw new IllegalArgumentException("YouTube videoId를 추출할 수 없습니다.");
+  }
+
+  private static String extractFromShortUrl(String path) {
+    if (path != null && path.length() > 1) {
+      return path.substring(1).split("/")[0];
+    }
+
+    throw new IllegalArgumentException("YouTube videoId를 추출할 수 없습니다.");
+  }
+
+  private static String extractFromQuery(String query) {
+    if (query == null) {
+      return null;
+    }
+
+    for (String param : query.split("&")) {
+      String[] pair = param.split("=", 2);
+
+      if (pair.length == 2 && pair[0].equals("v")) {
+        return pair[1];
+      }
+    }
+
+    return null;
+  }
+
+  private static String extractFromPath(String path) {
+    if (path == null) {
+      throw new IllegalArgumentException("YouTube videoId를 추출할 수 없습니다.");
+    }
+
+    if (path.startsWith("/shorts/")) {
+      return path.replace("/shorts/", "").split("/")[0];
+    }
+
+    if (path.startsWith("/embed/")) {
+      return path.replace("/embed/", "").split("/")[0];
+    }
+
+    throw new IllegalArgumentException("YouTube videoId를 추출할 수 없습니다.");
+  }
+}


### PR DESCRIPTION
## 작업 개요
- YouTube 동일 영상 분석 요청 시 기존 COMPLETED Job 결과 재사용하는 캐시 기능 구현
## 관련 이슈
- close #68

## 작업 내용
- YoutubeUrlUtils 구현
- Project 엔티티에 youtubeVideoId 필드 추가
- 프로젝트 생성 시 YouTube videoId 저장 로직 추가
- 기존 COMPLETED Job 조회 로직 구현
- ResultCacheService / ResultCopyService 구현
- Segment / OCR 결과 복사 기능 구현
- 캐시 hit 시 Redis enqueue 생략 처리
- Job 생성 응답에 cached 필드 추가

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항
- 현재는 YouTube 기반 캐시만 지원
- LearningContent 캐시는 추후 확장 예정