### PR TITLE
feat: SavedWord 엔티티 생성

### DIFF
--- a/backend/src/main/java/com/overlang/domain/savedword/entity/SavedWord.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/entity/SavedWord.java
@@ -1,0 +1,50 @@
+package com.overlang.domain.savedword.entity;
+
+import com.overlang.domain.common.BaseTimeEntity;
+import com.overlang.domain.member.entity.Member;
+import com.overlang.domain.segment.entity.SegmentWord;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "saved_words")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SavedWord extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "segment_word_id", nullable = false)
+  private SegmentWord segmentWord;
+
+  @Column(columnDefinition = "TEXT")
+  private String meaning;
+
+  @Column(name = "context_meaning", columnDefinition = "TEXT")
+  private String contextMeaning;
+
+  @Column(columnDefinition = "TEXT")
+  private String memo;
+
+  public SavedWord(
+      Member member, SegmentWord segmentWord, String meaning, String contextMeaning, String memo) {
+    this.member = member;
+    this.segmentWord = segmentWord;
+    this.meaning = meaning;
+    this.contextMeaning = contextMeaning;
+    this.memo = memo;
+  }
+
+  public void updateMemo(String memo) {
+    this.memo = memo;
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -1,0 +1,6 @@
+package com.overlang.domain.savedword.repository;
+
+import com.overlang.domain.savedword.entity.SavedWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {}


### PR DESCRIPTION
## 작업 개요
- 학습 기능의 단어 찜하기 및 마이페이지 단어장 기능을 위한 SavedWord 저장 구조 생성
## 관련 이슈
- close #74

## 작업 내용
- SavedWord 엔티티 생성
- saved_words 테이블 구조 정의
- Member / SegmentWord 연관관계 설정
- 뜻, 문맥 의미, 메모 필드 추가
- SavedWordRepository 생성

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항