### PR TITLE
feat: SaveWord API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/SavedWordController.java
+++ b/backend/src/main/java/com/overlang/api/controller/SavedWordController.java
@@ -1,0 +1,44 @@
+package com.overlang.api.controller;
+
+import com.overlang.api.dto.savedword.SavedWordCreateRequest;
+import com.overlang.api.dto.savedword.SavedWordResponse;
+import com.overlang.domain.savedword.service.SavedWordService;
+import com.overlang.global.auth.AuthInterceptor;
+import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class SavedWordController {
+
+  private final SavedWordService savedWordService;
+
+  @Operation(summary = "저장 단어 생성", description = "사용자가 선택한 단어를 저장합니다.")
+  @PostMapping("/saved-words")
+  public ApiResponse<SavedWordResponse> createSavedWord(
+      HttpServletRequest httpRequest, @RequestBody SavedWordCreateRequest request) {
+    Long memberId = (Long) httpRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+    return ApiResponse.success(savedWordService.createSavedWord(memberId, request));
+  }
+
+  @Operation(summary = "내 저장 단어 목록 조회", description = "사용자가 저장한 단어 목록을 최신순으로 조회합니다.")
+  @GetMapping("/me/saved-words")
+  public ApiResponse<List<SavedWordResponse>> getMySavedWords(HttpServletRequest httpRequest) {
+    Long memberId = (Long) httpRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+    return ApiResponse.success(savedWordService.getMySavedWords(memberId));
+  }
+
+  @Operation(summary = "저장 단어 삭제", description = "사용자가 저장한 단어를 삭제합니다.")
+  @DeleteMapping("/saved-words/{savedWordId}")
+  public ApiResponse<Void> deleteSavedWord(
+      HttpServletRequest httpRequest, @PathVariable Long savedWordId) {
+    Long memberId = (Long) httpRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+    savedWordService.deleteSavedWord(memberId, savedWordId);
+    return ApiResponse.success(null);
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordCreateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordCreateRequest.java
@@ -1,0 +1,4 @@
+package com.overlang.api.dto.savedword;
+
+public record SavedWordCreateRequest(
+    Long segmentWordId, String meaning, String contextMeaning, String memo) {}

--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
@@ -1,0 +1,42 @@
+package com.overlang.api.dto.savedword;
+
+import com.overlang.domain.savedword.entity.SavedWord;
+import java.time.Instant;
+
+public record SavedWordResponse(
+    Long savedWordId,
+    Long segmentWordId,
+    String word,
+    String meaning,
+    String contextMeaning,
+    String memo,
+    Double startTime,
+    Double endTime,
+    String originalSentence,
+    String translatedSentence,
+    Long projectId,
+    String projectTitle,
+    Instant createdAt) {
+
+  public static SavedWordResponse from(SavedWord savedWord) {
+    var segmentWord = savedWord.getSegmentWord();
+    var segment = segmentWord.getSegment();
+    var job = segment.getJob();
+    var project = job.getProject();
+
+    return new SavedWordResponse(
+        savedWord.getId(),
+        segmentWord.getId(),
+        segmentWord.getWord(),
+        savedWord.getMeaning(),
+        savedWord.getContextMeaning(),
+        savedWord.getMemo(),
+        segmentWord.getStartTime(),
+        segmentWord.getEndTime(),
+        segment.getText(),
+        segment.getTranslatedText(),
+        project.getId(),
+        project.getTitle(),
+        savedWord.getCreatedAt());
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -1,6 +1,15 @@
 package com.overlang.domain.savedword.repository;
 
 import com.overlang.domain.savedword.entity.SavedWord;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {}
+public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
+
+  boolean existsByMemberIdAndSegmentWordId(Long memberId, Long segmentWordId);
+
+  List<SavedWord> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+  Optional<SavedWord> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
@@ -1,0 +1,67 @@
+package com.overlang.domain.savedword.service;
+
+import com.overlang.api.dto.savedword.SavedWordCreateRequest;
+import com.overlang.api.dto.savedword.SavedWordResponse;
+import com.overlang.domain.member.entity.Member;
+import com.overlang.domain.member.repository.MemberRepository;
+import com.overlang.domain.savedword.entity.SavedWord;
+import com.overlang.domain.savedword.repository.SavedWordRepository;
+import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.repository.SegmentWordRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SavedWordService {
+
+  private final SavedWordRepository savedWordRepository;
+  private final MemberRepository memberRepository;
+  private final SegmentWordRepository segmentWordRepository;
+
+  @Transactional
+  public SavedWordResponse createSavedWord(Long memberId, SavedWordCreateRequest request) {
+    if (request.segmentWordId() == null) {
+      throw new IllegalArgumentException("segmentWordId는 필수입니다.");
+    }
+
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+    SegmentWord segmentWord =
+        segmentWordRepository
+            .findById(request.segmentWordId())
+            .orElseThrow(() -> new IllegalArgumentException("세그먼트 단어를 찾을 수 없습니다."));
+
+    if (savedWordRepository.existsByMemberIdAndSegmentWordId(memberId, request.segmentWordId())) {
+      throw new IllegalArgumentException("이미 저장한 단어입니다.");
+    }
+
+    SavedWord savedWord =
+        new SavedWord(
+            member, segmentWord, request.meaning(), request.contextMeaning(), request.memo());
+
+    return SavedWordResponse.from(savedWordRepository.save(savedWord));
+  }
+
+  @Transactional(readOnly = true)
+  public List<SavedWordResponse> getMySavedWords(Long memberId) {
+    return savedWordRepository.findByMemberIdOrderByCreatedAtDesc(memberId).stream()
+        .map(SavedWordResponse::from)
+        .toList();
+  }
+
+  @Transactional
+  public void deleteSavedWord(Long memberId, Long savedWordId) {
+    SavedWord savedWord =
+        savedWordRepository
+            .findByIdAndMemberId(savedWordId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
+
+    savedWordRepository.delete(savedWord);
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -1,0 +1,6 @@
+package com.overlang.domain.segment.repository;
+
+import com.overlang.domain.segment.entity.SegmentWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {}


### PR DESCRIPTION
## 작업 개요
- SavedWord API 구현
## 관련 이슈
- close #76 

## 작업 내용
- 저장 단어 생성 API 구현
- 내 저장 단어 목록 조회 API 구현
- 저장 단어 삭제 API 구현
- SegmentWord 기반 저장 처리 구현
- 사용자별 저장 데이터 검증 처리
- 중복 저장 검증 처리

## 체크리스트 (DoD)
- [X] 빌드 및 테스트 통과 확인
- [X] (BE만) `./gradlew spotlessApply` 실행 완료
- [X] 관련 API 문서(Swagger 등) 업데이트 완료
- [X] Self-Review 완료

## UI 스크린샷 (해당 시)
- 저장한 단어 생성
<img width="2097" height="625" alt="image" src="https://github.com/user-attachments/assets/07b56b86-d318-4af2-8948-a68f79de3430" />
- 저장한 단어 조회
<img width="2267" height="797" alt="image" src="https://github.com/user-attachments/assets/c4599ac3-6154-4abf-abbe-3f8a28ef0640" />
- 저장한 단어 삭제
<img width="1358" height="282" alt="image" src="https://github.com/user-attachments/assets/9a7ac640-8f4b-46ba-abd3-d35dc08eb62c" />

## 기타 사항
- SegmentWord 기반으로 저장 단어를 관리하도록 구현
- 동일 사용자의 중복 저장을 방지하도록 처리