### PR TITLE
feat: STT 자막 분리 정책 개선

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -75,6 +75,48 @@ def main() -> None:
         help="Skip alignment step for speed",
     )
     parser.add_argument(
+        "--stt-min-segment-seconds",
+        type=float,
+        default=0.2,
+        help="Minimum subtitle segment duration before merging with the previous segment",
+    )
+    parser.add_argument(
+        "--stt-max-segment-seconds",
+        type=float,
+        default=15.0,
+        help="Maximum source subtitle duration before safety splitting long STT output",
+    )
+    parser.add_argument(
+        "--stt-max-segment-chars",
+        type=int,
+        default=220,
+        help="Maximum source subtitle text length before safety splitting long STT output",
+    )
+    parser.add_argument(
+        "--stt-min-split-seconds",
+        type=float,
+        default=1.0,
+        help="Minimum duration for sentence-boundary STT split chunks",
+    )
+    parser.add_argument(
+        "--translated-subtitle-max-seconds",
+        type=float,
+        default=8.0,
+        help="Maximum rendered translated subtitle duration before splitting",
+    )
+    parser.add_argument(
+        "--translated-subtitle-max-chars",
+        type=int,
+        default=0,
+        help="Maximum rendered translated subtitle length. Use 0 for two-line language defaults.",
+    )
+    parser.add_argument(
+        "--translated-subtitle-min-split-seconds",
+        type=float,
+        default=1.5,
+        help="Minimum duration for rendered translated subtitle chunks",
+    )
+    parser.add_argument(
         "--frame-interval",
         type=float,
         default=1.0,
@@ -153,6 +195,15 @@ def main() -> None:
             "compute_type": args.compute_type,
             "batch_size": args.batch_size,
             "no_align": args.no_align,
+            "stt_min_segment_seconds": args.stt_min_segment_seconds,
+            "stt_max_segment_seconds": args.stt_max_segment_seconds,
+            "stt_max_segment_chars": args.stt_max_segment_chars,
+            "stt_min_split_seconds": args.stt_min_split_seconds,
+            "translated_subtitle_max_seconds": args.translated_subtitle_max_seconds,
+            "translated_subtitle_max_chars": args.translated_subtitle_max_chars,
+            "translated_subtitle_min_split_seconds": (
+                args.translated_subtitle_min_split_seconds
+            ),
             "frame_interval": args.frame_interval,
             "ocr_gpu": not args.ocr_cpu,
             "ocr_change_threshold": args.ocr_change_threshold,

--- a/ai/pipeline/run_pipeline.py
+++ b/ai/pipeline/run_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 from pathlib import Path
 from typing import Any, Callable
@@ -34,6 +35,149 @@ from ai.stt_service import STTService
 from ai.translation import create_translation_service
 
 ProgressCallback = Callable[[CurrentStage, float, dict[str, Any] | None], None]
+
+SOFT_SPLIT_WORDS = {
+    # English
+    "i",
+    "you",
+    "he",
+    "she",
+    "we",
+    "they",
+    "it",
+    "this",
+    "that",
+    "these",
+    "those",
+    "there",
+    "but",
+    "and",
+    "so",
+    "because",
+    "when",
+    "while",
+    "if",
+    "though",
+    "although",
+    "who",
+    "which",
+    "where",
+    "what",
+    "how",
+    "why",
+    "darling",
+    "baby",
+    # Korean
+    "나",
+    "내",
+    "저",
+    "제",
+    "너",
+    "당신",
+    "우리",
+    "그",
+    "그녀",
+    "그들",
+    "하지만",
+    "그리고",
+    "그래서",
+    "그러나",
+    "왜냐하면",
+    "만약",
+    "때문에",
+    "그러면",
+    # Chinese
+    "我",
+    "你",
+    "他",
+    "她",
+    "我们",
+    "你们",
+    "他们",
+    "但是",
+    "可是",
+    "然后",
+    "所以",
+    "因为",
+    "如果",
+    "当",
+    # Japanese
+    "私",
+    "僕",
+    "俺",
+    "あなた",
+    "君",
+    "彼",
+    "彼女",
+    "私たち",
+    "でも",
+    "しかし",
+    "そして",
+    "だから",
+    "それで",
+    "なぜなら",
+    "もし",
+    # Spanish
+    "yo",
+    "tú",
+    "tu",
+    "usted",
+    "él",
+    "el",
+    "ella",
+    "nosotros",
+    "nosotras",
+    "vosotros",
+    "vosotras",
+    "ellos",
+    "ellas",
+    "pero",
+    "y",
+    "entonces",
+    "porque",
+    "cuando",
+    "si",
+    "aunque",
+    "que",
+    # French
+    "je",
+    "j",
+    "tu",
+    "vous",
+    "il",
+    "elle",
+    "nous",
+    "ils",
+    "elles",
+    "mais",
+    "et",
+    "donc",
+    "parce",
+    "quand",
+    "si",
+    "lorsque",
+    "que",
+}
+
+COMPACT_TEXT_LANGUAGES = {"ja", "ja-jp", "zh", "zh-cn", "zh-tw", "zh-hans", "zh-hant"}
+SENTENCE_BOUNDARY_SUFFIXES = (".", "?", "!", "。", "？", "！")
+RENDER_MAX_SUBTITLE_LINES = 2
+RENDER_MIN_SUBTITLE_CHARS = 12
+RENDER_TARGET_SECONDS_PER_SUBTITLE = 6.0
+RENDER_COMFORTABLE_SUBTITLE_CHARS_RATIO = 0.75
+RENDER_MAX_LINE_LENGTHS = {
+    "ko": 28,
+    "en": 45,
+    "zh": 22,
+    "zh-cn": 22,
+    "zh-tw": 22,
+    "zh-hans": 22,
+    "zh-hant": 22,
+    "ja": 22,
+    "ja-jp": 22,
+    "es": 42,
+    "fr": 42,
+}
 
 
 def run_pipeline(
@@ -126,6 +270,17 @@ def run_pipeline(
                     ocr_items,
                     resolved_source_language,
                 )
+            )
+            subtitles = _split_translated_subtitles_for_rendering(
+                subtitles,
+                target_language=normalized_job.target_language,
+                max_duration_seconds=float(
+                    runtime_options["translated_subtitle_max_seconds"]
+                ),
+                max_text_length=int(runtime_options["translated_subtitle_max_chars"]),
+                min_split_duration_seconds=float(
+                    runtime_options["translated_subtitle_min_split_seconds"]
+                ),
             )
             save_intermediate(
                 resolved_job_id,
@@ -243,7 +398,13 @@ def _run_stt_stage(
     finally:
         stt_service.unload_model()
 
-    return _postprocess_subtitles(_build_subtitles(raw_segments, job.source_language))
+    return _postprocess_subtitles(
+        _build_subtitles(raw_segments, job.source_language),
+        min_duration_seconds=float(runtime_options["stt_min_segment_seconds"]),
+        max_duration_seconds=float(runtime_options["stt_max_segment_seconds"]),
+        max_text_length=int(runtime_options["stt_max_segment_chars"]),
+        min_split_duration_seconds=float(runtime_options["stt_min_split_seconds"]),
+    )
 
 
 def _run_ocr_stage(
@@ -373,6 +534,349 @@ def _run_translation_stage(
     return []
 
 
+def _split_translated_subtitles_for_rendering(
+    subtitles: list[SubtitleSegment],
+    target_language: str | None,
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    if not target_language:
+        return subtitles
+
+    resolved_max_text_length = _resolve_render_max_text_length(
+        target_language,
+        max_text_length,
+    )
+    split_subtitles: list[SubtitleSegment] = []
+    for subtitle in subtitles:
+        split_subtitles.extend(
+            _split_translated_subtitle_for_rendering(
+                subtitle,
+                target_language=target_language,
+                max_duration_seconds=max_duration_seconds,
+                max_text_length=resolved_max_text_length,
+                min_split_duration_seconds=min_split_duration_seconds,
+            )
+        )
+
+    split_subtitles = _merge_short_translated_subtitles(
+        split_subtitles,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=resolved_max_text_length,
+    )
+    split_subtitles = _merge_compact_translated_subtitles(
+        split_subtitles,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=resolved_max_text_length,
+    )
+
+    for index, subtitle in enumerate(split_subtitles, start=1):
+        subtitle.seq = index
+
+    return split_subtitles
+
+
+def _split_translated_subtitle_for_rendering(
+    subtitle: SubtitleSegment,
+    target_language: str,
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    translated_text = (subtitle.translated_text or "").strip()
+    duration = subtitle.end_time - subtitle.start_time
+    if (
+        not translated_text
+        or (
+            duration <= max_duration_seconds
+            and len(translated_text) <= max_text_length
+        )
+    ):
+        return [subtitle]
+
+    chunks = _split_text_for_rendering(
+        translated_text,
+        language_code=target_language,
+        total_duration=duration,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=max_text_length,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+    if len(chunks) <= 1:
+        return [subtitle]
+
+    return _build_translated_render_chunks(
+        subtitle,
+        translated_chunks=chunks,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+
+
+def _split_text_for_rendering(
+    text: str,
+    language_code: str | None,
+    total_duration: float,
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[str]:
+    tokens = text.split()
+    if _is_compact_language(language_code):
+        tokens = _split_compact_text(text)
+
+    if not tokens:
+        return [text]
+
+    chunks: list[list[str]] = []
+    current_chunk: list[str] = []
+    for token in tokens:
+        current_chunk.append(token)
+        chunk_text = _join_text_tokens(current_chunk, language_code)
+        if _has_sentence_boundary(token) or len(chunk_text) >= max_text_length:
+            chunks.append(current_chunk)
+            current_chunk = []
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    chunks = _ensure_text_chunk_limits(
+        chunks,
+        total_duration=total_duration,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=max_text_length,
+        language_code=language_code,
+    )
+    chunks = _merge_text_chunks_for_min_duration(
+        chunks,
+        total_duration=total_duration,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+    chunks = _rebalance_short_text_chunks(
+        chunks,
+        language_code=language_code,
+        max_text_length=max_text_length,
+    )
+
+    return [
+        _join_text_tokens(chunk, language_code)
+        for chunk in chunks
+        if _join_text_tokens(chunk, language_code)
+    ]
+
+
+def _build_translated_render_chunks(
+    subtitle: SubtitleSegment,
+    translated_chunks: list[str],
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    split_subtitles = []
+    previous_end_time = subtitle.start_time
+
+    for index, translated_chunk in enumerate(translated_chunks):
+        start_time = previous_end_time
+        if index == len(translated_chunks) - 1:
+            end_time = subtitle.end_time
+        else:
+            remaining_chunks = len(translated_chunks) - index - 1
+            latest_end_time = subtitle.end_time - (
+                min_split_duration_seconds * remaining_chunks
+            )
+            end_time = min(
+                start_time
+                + ((subtitle.end_time - start_time) / (remaining_chunks + 1)),
+                latest_end_time,
+            )
+
+        start_time = _round_time(start_time)
+        end_time = _round_time(end_time)
+        if end_time <= start_time:
+            continue
+
+        words = _select_words_for_time_range(subtitle.words, start_time, end_time)
+        source_text = _resolve_source_text_for_render_chunk(
+            subtitle,
+            words,
+            index=index,
+            total_chunks=len(translated_chunks),
+        )
+        split_subtitles.append(
+            SubtitleSegment(
+                seq=subtitle.seq,
+                start_time=start_time,
+                end_time=end_time,
+                text=source_text,
+                translated_text=translated_chunk,
+                language_code=subtitle.language_code,
+                words=words,
+            )
+        )
+        previous_end_time = end_time
+
+    return split_subtitles or [subtitle]
+
+
+def _merge_short_translated_subtitles(
+    subtitles: list[SubtitleSegment],
+    max_duration_seconds: float,
+    max_text_length: int,
+) -> list[SubtitleSegment]:
+    merged_subtitles: list[SubtitleSegment] = []
+    pending_subtitles = list(subtitles)
+
+    while pending_subtitles:
+        subtitle = pending_subtitles.pop(0)
+        if not _is_short_translated_subtitle(subtitle):
+            merged_subtitles.append(subtitle)
+            continue
+
+        if merged_subtitles and _can_merge_translated_subtitles(
+            merged_subtitles[-1],
+            subtitle,
+            max_duration_seconds=max_duration_seconds,
+            max_text_length=max_text_length,
+        ):
+            _merge_translated_subtitle_pair(merged_subtitles[-1], subtitle)
+            continue
+
+        if pending_subtitles and _can_merge_translated_subtitles(
+            subtitle,
+            pending_subtitles[0],
+            max_duration_seconds=max_duration_seconds,
+            max_text_length=max_text_length,
+        ):
+            next_subtitle = pending_subtitles.pop(0)
+            _merge_translated_subtitle_pair(subtitle, next_subtitle)
+            merged_subtitles.append(subtitle)
+            continue
+
+        merged_subtitles.append(subtitle)
+
+    return merged_subtitles
+
+
+def _merge_compact_translated_subtitles(
+    subtitles: list[SubtitleSegment],
+    max_duration_seconds: float,
+    max_text_length: int,
+) -> list[SubtitleSegment]:
+    if not subtitles:
+        return subtitles
+
+    compact_max_text_length = max(
+        RENDER_MIN_SUBTITLE_CHARS,
+        int(max_text_length * RENDER_COMFORTABLE_SUBTITLE_CHARS_RATIO),
+    )
+    merged_subtitles: list[SubtitleSegment] = []
+    for subtitle in subtitles:
+        if merged_subtitles and _can_merge_translated_subtitles(
+            merged_subtitles[-1],
+            subtitle,
+            max_duration_seconds=max_duration_seconds,
+            max_text_length=compact_max_text_length,
+        ):
+            _merge_translated_subtitle_pair(merged_subtitles[-1], subtitle)
+            continue
+
+        merged_subtitles.append(subtitle)
+
+    return merged_subtitles
+
+
+def _is_short_translated_subtitle(subtitle: SubtitleSegment) -> bool:
+    translated_text = (subtitle.translated_text or "").replace(" ", "")
+    return 0 < len(translated_text) < RENDER_MIN_SUBTITLE_CHARS
+
+
+def _can_merge_translated_subtitles(
+    first: SubtitleSegment,
+    second: SubtitleSegment,
+    max_duration_seconds: float,
+    max_text_length: int,
+) -> bool:
+    if _has_sentence_boundary(first.translated_text or first.text):
+        return False
+
+    merged_duration = second.end_time - first.start_time
+    if merged_duration > max_duration_seconds:
+        return False
+
+    merged_text = _merge_display_texts(first.translated_text, second.translated_text)
+    return len(merged_text) <= max_text_length
+
+
+def _merge_translated_subtitle_pair(
+    first: SubtitleSegment,
+    second: SubtitleSegment,
+) -> None:
+    first.end_time = _round_time(max(first.end_time, second.end_time))
+    first.text = _merge_display_texts(first.text, second.text)
+    first.translated_text = _merge_display_texts(
+        first.translated_text,
+        second.translated_text,
+    )
+    first.words.extend(second.words)
+
+
+def _merge_display_texts(
+    first: str | None,
+    second: str | None,
+) -> str:
+    return " ".join(text.strip() for text in (first, second) if text and text.strip())
+
+
+def _select_words_for_time_range(
+    words: list[WordTiming],
+    start_time: float,
+    end_time: float,
+) -> list[WordTiming]:
+    selected_words = []
+    for word in words:
+        if word.start_time is None or word.end_time is None:
+            continue
+
+        if word.end_time <= start_time or word.start_time >= end_time:
+            continue
+
+        selected_words.append(word)
+
+    return selected_words
+
+
+def _resolve_source_text_for_render_chunk(
+    subtitle: SubtitleSegment,
+    words: list[WordTiming],
+    index: int,
+    total_chunks: int,
+) -> str:
+    if words:
+        return _join_word_texts(words, subtitle.language_code)
+
+    tokens = subtitle.text.split()
+    if _is_compact_language(subtitle.language_code):
+        tokens = _split_compact_text(subtitle.text)
+
+    if not tokens or total_chunks <= 1:
+        return subtitle.text
+
+    start_index = int(len(tokens) * index / total_chunks)
+    end_index = int(len(tokens) * (index + 1) / total_chunks)
+    source_text = _join_text_tokens(tokens[start_index:end_index], subtitle.language_code)
+    return source_text or subtitle.text
+
+
+def _resolve_render_max_text_length(
+    language_code: str | None,
+    configured_max_text_length: int,
+) -> int:
+    if configured_max_text_length > 0:
+        return configured_max_text_length
+
+    normalized_language = (language_code or "").lower()
+    max_line_length = RENDER_MAX_LINE_LENGTHS.get(normalized_language, 45)
+    return max_line_length * RENDER_MAX_SUBTITLE_LINES
+
+
 def _build_subtitles(
     raw_segments: list[dict[str, Any]],
     source_language: str | None,
@@ -416,6 +920,9 @@ def _build_word_timings(words: list[dict[str, Any]]) -> list[WordTiming]:
 def _postprocess_subtitles(
     subtitles: list[SubtitleSegment],
     min_duration_seconds: float = 0.2,
+    max_duration_seconds: float = 7.0,
+    max_text_length: int = 90,
+    min_split_duration_seconds: float = 1.0,
 ) -> list[SubtitleSegment]:
     cleaned_subtitles = [
         subtitle
@@ -441,10 +948,511 @@ def _postprocess_subtitles(
         subtitle.end_time = _round_time(subtitle.end_time)
         merged_subtitles.append(subtitle)
 
-    for index, subtitle in enumerate(merged_subtitles, start=1):
+    split_subtitles: list[SubtitleSegment] = []
+    for subtitle in merged_subtitles:
+        split_subtitles.extend(
+            _split_long_subtitle(
+                subtitle,
+                max_duration_seconds=max_duration_seconds,
+                max_text_length=max_text_length,
+                min_split_duration_seconds=min_split_duration_seconds,
+            )
+        )
+
+    for index, subtitle in enumerate(split_subtitles, start=1):
         subtitle.seq = index
 
-    return merged_subtitles
+    return split_subtitles
+
+
+def _split_long_subtitle(
+    subtitle: SubtitleSegment,
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    duration = subtitle.end_time - subtitle.start_time
+    if duration <= max_duration_seconds and len(subtitle.text) <= max_text_length:
+        return [subtitle]
+
+    timed_words = [
+        word
+        for word in subtitle.words
+        if word.start_time is not None and word.end_time is not None
+    ]
+    if subtitle.words and len(timed_words) == len(subtitle.words):
+        return _split_subtitle_by_words(
+            subtitle,
+            timed_words,
+            max_duration_seconds=max_duration_seconds,
+            max_text_length=max_text_length,
+            min_split_duration_seconds=min_split_duration_seconds,
+        )
+
+    return _split_subtitle_by_text(
+        subtitle,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=max_text_length,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+
+
+def _split_subtitle_by_words(
+    subtitle: SubtitleSegment,
+    words: list[WordTiming],
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    chunks: list[list[WordTiming]] = []
+    current_chunk: list[WordTiming] = []
+
+    for word in words:
+        current_chunk.append(word)
+        chunk_text = _join_word_texts(current_chunk, subtitle.language_code)
+        chunk_start = current_chunk[0].start_time or subtitle.start_time
+        chunk_end = current_chunk[-1].end_time or subtitle.end_time
+        chunk_duration = chunk_end - chunk_start
+
+        can_split = chunk_duration >= min_split_duration_seconds
+        reached_limit = (
+            chunk_duration >= max_duration_seconds or len(chunk_text) >= max_text_length
+        )
+        reached_sentence_boundary = _has_sentence_boundary(word.word) and can_split
+
+        if reached_sentence_boundary:
+            chunks.append(current_chunk)
+            current_chunk = []
+            continue
+
+        if reached_limit:
+            split_chunk, remaining_chunk = _split_word_chunk_at_best_boundary(
+                current_chunk,
+                min_split_duration_seconds=min_split_duration_seconds,
+            )
+            chunks.append(split_chunk)
+            current_chunk = remaining_chunk
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    chunks = _merge_short_word_chunks(
+        chunks,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+    return _build_subtitle_chunks_from_words(subtitle, chunks)
+
+
+def _split_word_chunk_at_best_boundary(
+    chunk: list[WordTiming],
+    min_split_duration_seconds: float,
+) -> tuple[list[WordTiming], list[WordTiming]]:
+    split_index = _find_best_word_split_index(
+        chunk,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+    if split_index is None:
+        return chunk, []
+
+    return chunk[:split_index], chunk[split_index:]
+
+
+def _find_best_word_split_index(
+    chunk: list[WordTiming],
+    min_split_duration_seconds: float,
+) -> int | None:
+    if len(chunk) <= 2:
+        return None
+
+    candidates = []
+    for index in range(1, len(chunk)):
+        previous = chunk[index - 1]
+        current = chunk[index]
+        start_time = chunk[0].start_time or 0
+        previous_end_time = previous.end_time or start_time
+        duration = previous_end_time - start_time
+        if duration < min_split_duration_seconds:
+            continue
+
+        if _has_sentence_boundary(previous.word) or _is_soft_split_word(current.word):
+            candidates.append(index)
+
+    if not candidates:
+        return None
+
+    target_index = max(1, int(len(chunk) * 0.6))
+    return min(candidates, key=lambda index: abs(index - target_index))
+
+
+def _build_subtitle_chunks_from_words(
+    subtitle: SubtitleSegment,
+    chunks: list[list[WordTiming]],
+) -> list[SubtitleSegment]:
+    split_subtitles = []
+    previous_end_time = subtitle.start_time
+    for chunk in chunks:
+        if not chunk:
+            continue
+
+        start_time = _round_time(
+            max(chunk[0].start_time or subtitle.start_time, previous_end_time)
+        )
+        end_time = _round_time(chunk[-1].end_time or subtitle.end_time)
+        if end_time <= start_time:
+            continue
+
+        split_subtitles.append(
+            SubtitleSegment(
+                seq=subtitle.seq,
+                start_time=start_time,
+                end_time=end_time,
+                text=_join_word_texts(chunk, subtitle.language_code),
+                translated_text=subtitle.translated_text,
+                language_code=subtitle.language_code,
+                words=chunk,
+            )
+        )
+        previous_end_time = end_time
+
+    return split_subtitles or [subtitle]
+
+
+def _merge_short_word_chunks(
+    chunks: list[list[WordTiming]],
+    min_split_duration_seconds: float,
+) -> list[list[WordTiming]]:
+    merged_chunks: list[list[WordTiming]] = []
+    for chunk in chunks:
+        if not chunk:
+            continue
+
+        chunk_duration = (chunk[-1].end_time or 0) - (chunk[0].start_time or 0)
+        if merged_chunks and chunk_duration < min_split_duration_seconds:
+            merged_chunks[-1].extend(chunk)
+            continue
+
+        merged_chunks.append(chunk)
+
+    return merged_chunks
+
+
+def _split_subtitle_by_text(
+    subtitle: SubtitleSegment,
+    max_duration_seconds: float,
+    max_text_length: int,
+    min_split_duration_seconds: float,
+) -> list[SubtitleSegment]:
+    words = subtitle.text.split()
+    if _is_compact_language(subtitle.language_code):
+        words = _split_compact_text(subtitle.text)
+
+    if not words:
+        return [subtitle]
+
+    chunks: list[list[str]] = []
+    current_chunk: list[str] = []
+    for word in words:
+        current_chunk.append(word)
+        chunk_text = _join_text_tokens(current_chunk, subtitle.language_code)
+        if _has_sentence_boundary(word) or len(chunk_text) >= max_text_length:
+            chunks.append(current_chunk)
+            current_chunk = []
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    total_duration = subtitle.end_time - subtitle.start_time
+    chunks = _ensure_text_chunk_limits(
+        chunks,
+        total_duration=total_duration,
+        max_duration_seconds=max_duration_seconds,
+        max_text_length=max_text_length,
+        language_code=subtitle.language_code,
+    )
+    chunks = _merge_text_chunks_for_min_duration(
+        chunks,
+        total_duration=total_duration,
+        min_split_duration_seconds=min_split_duration_seconds,
+    )
+    if len(chunks) <= 1:
+        return [subtitle]
+
+    split_subtitles = []
+    previous_end_time = subtitle.start_time
+    for index, chunk in enumerate(chunks):
+        start_time = previous_end_time
+        remaining_chunks = len(chunks) - index
+        remaining_duration = subtitle.end_time - start_time
+        chunk_duration = max(
+            min_split_duration_seconds,
+            remaining_duration / remaining_chunks,
+        )
+        end_time = (
+            subtitle.end_time
+            if index == len(chunks) - 1
+            else start_time + chunk_duration
+        )
+        start_time = _round_time(start_time)
+        end_time = _round_time(end_time)
+        if end_time <= start_time:
+            continue
+
+        split_subtitles.append(
+            SubtitleSegment(
+                seq=subtitle.seq,
+                start_time=start_time,
+                end_time=end_time,
+                text=_join_text_tokens(chunk, subtitle.language_code),
+                translated_text=subtitle.translated_text,
+                language_code=subtitle.language_code,
+                words=[],
+            )
+        )
+        previous_end_time = end_time
+
+    return split_subtitles or [subtitle]
+
+
+def _ensure_text_chunk_limits(
+    chunks: list[list[str]],
+    total_duration: float,
+    max_duration_seconds: float,
+    max_text_length: int,
+    language_code: str | None = None,
+) -> list[list[str]]:
+    text_length = sum(len(_join_text_tokens(chunk, language_code)) for chunk in chunks)
+    required_by_duration = max(
+        1,
+        math.ceil(total_duration / max_duration_seconds),
+    )
+    required_by_text = max(1, math.ceil(text_length / max_text_length))
+    target_by_duration = max(
+        1,
+        round(total_duration / RENDER_TARGET_SECONDS_PER_SUBTITLE),
+    )
+    required_chunks = max(required_by_duration, required_by_text)
+    required_chunks = min(
+        required_chunks,
+        max(required_by_text, target_by_duration),
+    )
+    limited_chunks = [list(chunk) for chunk in chunks if chunk]
+
+    while len(limited_chunks) < required_chunks:
+        split_index = _find_longest_text_chunk_index(limited_chunks, language_code)
+        chunk = limited_chunks[split_index]
+        if len(chunk) <= 1:
+            break
+
+        middle = _find_best_text_split_index(chunk) or max(1, len(chunk) // 2)
+        limited_chunks[split_index : split_index + 1] = [
+            chunk[:middle],
+            chunk[middle:],
+        ]
+
+    return limited_chunks
+
+
+def _find_longest_text_chunk_index(
+    chunks: list[list[str]],
+    language_code: str | None = None,
+) -> int:
+    return max(
+        range(len(chunks)),
+        key=lambda index: len(_join_text_tokens(chunks[index], language_code)),
+    )
+
+
+def _find_best_text_split_index(chunk: list[str]) -> int | None:
+    if len(chunk) <= 2:
+        return None
+
+    candidates = []
+    for index in range(1, len(chunk)):
+        previous = chunk[index - 1]
+        current = chunk[index]
+        if _has_sentence_boundary(previous) or _is_soft_split_word(current):
+            candidates.append(index)
+
+    if not candidates:
+        return None
+
+    target_index = max(1, int(len(chunk) * 0.6))
+    return min(candidates, key=lambda index: abs(index - target_index))
+
+
+def _merge_text_chunks_for_min_duration(
+    chunks: list[list[str]],
+    total_duration: float,
+    min_split_duration_seconds: float,
+) -> list[list[str]]:
+    max_chunks = max(1, int(total_duration // min_split_duration_seconds))
+    merged_chunks = [list(chunk) for chunk in chunks if chunk]
+    while len(merged_chunks) > max_chunks:
+        merged_chunks[-2].extend(merged_chunks[-1])
+        merged_chunks.pop()
+
+    return merged_chunks
+
+
+def _rebalance_short_text_chunks(
+    chunks: list[list[str]],
+    language_code: str | None,
+    max_text_length: int,
+) -> list[list[str]]:
+    rebalanced_chunks = [list(chunk) for chunk in chunks if chunk]
+
+    for _ in range(max(1, len(rebalanced_chunks) * 2)):
+        changed = False
+        for index, chunk in enumerate(rebalanced_chunks):
+            while (
+                0
+                < _render_text_length(chunk, language_code)
+                < RENDER_MIN_SUBTITLE_CHARS
+            ):
+                if _borrow_token_from_previous_chunk(
+                    rebalanced_chunks,
+                    index,
+                    language_code,
+                    max_text_length,
+                ):
+                    changed = True
+                    continue
+
+                if _borrow_token_from_next_chunk(
+                    rebalanced_chunks,
+                    index,
+                    language_code,
+                    max_text_length,
+                ):
+                    changed = True
+                    continue
+
+                break
+
+        if not changed:
+            break
+
+    return rebalanced_chunks
+
+
+def _borrow_token_from_previous_chunk(
+    chunks: list[list[str]],
+    index: int,
+    language_code: str | None,
+    max_text_length: int,
+) -> bool:
+    if index <= 0:
+        return False
+
+    previous_chunk = chunks[index - 1]
+    current_chunk = chunks[index]
+    if len(previous_chunk) <= 1:
+        return False
+
+    if _has_sentence_boundary(previous_chunk[-1]):
+        return False
+
+    candidate_chunk = [previous_chunk[-1], *current_chunk]
+    if _render_text_length(candidate_chunk, language_code) > max_text_length:
+        return False
+
+    previous_chunk.pop()
+    current_chunk.insert(0, candidate_chunk[0])
+    return True
+
+
+def _borrow_token_from_next_chunk(
+    chunks: list[list[str]],
+    index: int,
+    language_code: str | None,
+    max_text_length: int,
+) -> bool:
+    if index >= len(chunks) - 1:
+        return False
+
+    current_chunk = chunks[index]
+    next_chunk = chunks[index + 1]
+    if len(next_chunk) <= 1:
+        return False
+
+    if _has_sentence_boundary(current_chunk[-1]):
+        return False
+
+    candidate_chunk = [*current_chunk, next_chunk[0]]
+    if _render_text_length(candidate_chunk, language_code) > max_text_length:
+        return False
+
+    current_chunk.append(next_chunk.pop(0))
+    return True
+
+
+def _render_text_length(
+    tokens: list[str],
+    language_code: str | None,
+) -> int:
+    return len(_join_text_tokens(tokens, language_code).replace(" ", ""))
+
+
+def _join_word_texts(
+    words: list[WordTiming],
+    language_code: str | None = None,
+) -> str:
+    return _join_text_tokens(
+        [word.word for word in words],
+        language_code,
+    )
+
+
+def _join_text_tokens(tokens: list[str], language_code: str | None = None) -> str:
+    separator = "" if _is_compact_language(language_code) else " "
+    return separator.join(token.strip() for token in tokens if token.strip()).strip()
+
+
+def _has_sentence_boundary(text: str) -> bool:
+    return text.rstrip().endswith(SENTENCE_BOUNDARY_SUFFIXES)
+
+
+def _is_soft_split_word(text: str) -> bool:
+    normalized_text = text.strip().strip("\"'“”‘’()[]{}.,!?;:").lower()
+    return normalized_text in SOFT_SPLIT_WORDS
+
+
+def _is_compact_language(language_code: str | None) -> bool:
+    if not language_code:
+        return False
+
+    return language_code.lower() in COMPACT_TEXT_LANGUAGES
+
+
+def _split_compact_text(text: str) -> list[str]:
+    tokens = []
+    current_token = ""
+    for character in text:
+        if character.isspace():
+            if current_token:
+                tokens.extend(_split_long_compact_token(current_token))
+                current_token = ""
+            continue
+
+        current_token += character
+        if character in SENTENCE_BOUNDARY_SUFFIXES:
+            tokens.append(current_token)
+            current_token = ""
+
+    if current_token:
+        tokens.extend(_split_long_compact_token(current_token))
+
+    return tokens
+
+
+def _split_long_compact_token(token: str, max_token_length: int = 18) -> list[str]:
+    if len(token) <= max_token_length:
+        return [token]
+
+    return [
+        token[index : index + max_token_length]
+        for index in range(0, len(token), max_token_length)
+    ]
 
 
 def _resolve_source_language(
@@ -488,6 +1496,48 @@ def _extract_runtime_options(
         ),
         "align": not _to_bool(
             options.get("no_align", os.getenv("AI_DEFAULT_NO_ALIGN", "false"))
+        ),
+        "stt_min_segment_seconds": float(
+            options.get(
+                "stt_min_segment_seconds",
+                os.getenv("AI_STT_MIN_SEGMENT_SECONDS", "0.2"),
+            )
+        ),
+        "stt_max_segment_seconds": float(
+            options.get(
+                "stt_max_segment_seconds",
+                os.getenv("AI_STT_MAX_SEGMENT_SECONDS", "15.0"),
+            )
+        ),
+        "stt_max_segment_chars": int(
+            options.get(
+                "stt_max_segment_chars",
+                os.getenv("AI_STT_MAX_SEGMENT_CHARS", "220"),
+            )
+        ),
+        "stt_min_split_seconds": float(
+            options.get(
+                "stt_min_split_seconds",
+                os.getenv("AI_STT_MIN_SPLIT_SECONDS", "1.0"),
+            )
+        ),
+        "translated_subtitle_max_seconds": float(
+            options.get(
+                "translated_subtitle_max_seconds",
+                os.getenv("AI_TRANSLATED_SUBTITLE_MAX_SECONDS", "8.0"),
+            )
+        ),
+        "translated_subtitle_max_chars": int(
+            options.get(
+                "translated_subtitle_max_chars",
+                os.getenv("AI_TRANSLATED_SUBTITLE_MAX_CHARS", "0"),
+            )
+        ),
+        "translated_subtitle_min_split_seconds": float(
+            options.get(
+                "translated_subtitle_min_split_seconds",
+                os.getenv("AI_TRANSLATED_SUBTITLE_MIN_SPLIT_SECONDS", "1.5"),
+            )
         ),
         "frame_interval": float(
             options.get("frame_interval", os.getenv("AI_DEFAULT_FRAME_INTERVAL", "1.0"))


### PR DESCRIPTION
## 작업 개요
STT/번역 자막이 FE에서 과도하게 길거나 짧게 표시되는 문제를 개선했습니다.

## 관련 이슈
- close #82 

## 작업 내용
- STT 원문 segment 안전 분리 기준 추가
- 번역 후 translatedText 기준 FE 렌더링용 subtitle 재분리
- 언어별 한 줄 글자 수 및 최대 2줄 기준 적용
- subtitle 최대 표시 시간 기준 적용
- 너무 짧은 번역 subtitle 재분배 및 병합 보정
- 문장부호(. ? ! 。？！) 기준 강제 분리
- subtitle 시간 겹침 방지 및 seq 재정렬
- CLI에서 자막 분리 옵션 조정 가능하도록 추가

## 체크리스트 (DoD)
- [x]  빌드 및 테스트 통과 확인
- [ ]  (BE만) `./gradlew spotlessApply` 실행 완료
- [ ]  관련 API 문서(Swagger 등) 업데이트 완료
- [x]  Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항