### PR TITLE
feat: 번역 프롬프트 개선

### DIFF
--- a/ai/translation/service.py
+++ b/ai/translation/service.py
@@ -155,9 +155,21 @@ def _build_translation_instructions(
 ) -> str:
     source = _language_name(source_language) if source_language else "the detected language"
     target = _language_name(target_language)
+    target_native_name = _language_native_name(target_language)
     return (
         "You are a translation engine for a video language learning service. "
         f"Translate each input text from {source} to {target}. "
+        f"Every translation must be written only in {target} ({target_native_name}). "
+        "Do not mix in any other language unless the input contains an untranslatable "
+        "proper noun, brand name, title, or technical term. "
+        "If a word can be naturally translated, translate it instead of preserving "
+        "the source-language word. "
+        "For subtitles, prefer short, natural, spoken-language phrasing that is easy "
+        "to read on screen. "
+        "For OCR text, preserve the meaning and concise label-like form of the source. "
+        "Preserve numbers, symbols, product names, person names, and URLs as needed. "
+        "Translate idioms by meaning rather than word-for-word. "
+        "If the input is empty or whitespace, return an empty string for that item. "
         "Preserve the number and order of input texts exactly. "
         "Return only JSON that matches the provided schema. "
         "Do not add explanations, numbering, markdown, or extra fields."
@@ -172,6 +184,18 @@ def _language_name(language_code: str | None) -> str:
         "ja": "Japanese",
         "es": "Spanish",
         "fr": "French",
+    }
+    return names.get(language_code or "", language_code or "unknown language")
+
+
+def _language_native_name(language_code: str | None) -> str:
+    names = {
+        "ko": "한국어",
+        "en": "English",
+        "zh": "中文",
+        "ja": "日本語",
+        "es": "español",
+        "fr": "français",
     }
     return names.get(language_code or "", language_code or "unknown language")
 


### PR DESCRIPTION
## 작업 개요
OpenAI 번역 결과의 품질을 개선하기 위해 번역 프롬프트를 보강했습니다.

## 관련 이슈
- close #84 

## 작업 내용
- targetLanguage 언어로만 번역하도록 프롬프트 지시 강화
- 원문에 없는 외국어가 번역 결과에 섞이지 않도록 제한
- 자연스럽게 번역 가능한 단어는 원문 그대로 유지하지 않도록 지시
- 자막 번역은 화면에서 읽기 쉬운 짧고 자연스러운 문장으로 번역하도록 보완
- OCR 텍스트는 화면 텍스트 특성을 고려해 의미와 간결한 형태를 유지하도록 지시
- 숫자, 기호, 고유명사, URL 보존 정책 추가
- 관용표현은 직역보다 의미 중심으로 번역하도록 지시

## 체크리스트 (DoD)
- [x]  빌드 및 테스트 통과 확인
- [ ]  (BE만) `./gradlew spotlessApply` 실행 완료
- [ ]  관련 API 문서(Swagger 등) 업데이트 완료
- [x]  Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항