### PR TITLE
feat: Word API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/WordsController.java
+++ b/backend/src/main/java/com/overlang/api/controller/WordsController.java
@@ -1,0 +1,26 @@
+package com.overlang.api.controller;
+
+import com.overlang.api.dto.word.WordsExplainRequest;
+import com.overlang.api.dto.word.WordsExplainResponse;
+import com.overlang.domain.word.service.WordsExplainService;
+import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/words")
+public class WordsController {
+
+  private final WordsExplainService wordsExplainService;
+
+  @Operation(summary = "단어 설명 생성", description = "선택한 단어의 뜻과 관련 단어를 생성합니다. 원문/번역문 단어 모두 지원합니다.")
+  @PostMapping("/explain")
+  public ApiResponse<WordsExplainResponse> explain(
+      @Valid @RequestBody WordsExplainRequest request) {
+    WordsExplainResponse response = wordsExplainService.explain(request);
+    return ApiResponse.success(response);
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/word/WordsExplainRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/word/WordsExplainRequest.java
@@ -1,0 +1,13 @@
+package com.overlang.api.dto.word;
+
+import com.overlang.domain.word.entity.SelectedTextType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record WordsExplainRequest(
+    @NotBlank(message = "단어는 필수입니다.") String word,
+    @NotNull(message = "선택한 텍스트 타입은 필수입니다.") SelectedTextType selectedTextType,
+    @NotBlank(message = "원문 문장은 필수입니다.") String originalSentence,
+    @NotBlank(message = "번역 문장은 필수입니다.") String translatedSentence,
+    @NotBlank(message = "원본 언어는 필수입니다.") String sourceLanguage,
+    @NotBlank(message = "대상 언어는 필수입니다.") String targetLanguage) {}

--- a/backend/src/main/java/com/overlang/api/dto/word/WordsExplainResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/word/WordsExplainResponse.java
@@ -1,0 +1,5 @@
+package com.overlang.api.dto.word;
+
+import java.util.List;
+
+public record WordsExplainResponse(String word, String meaning, List<String> relatedWords) {}

--- a/backend/src/main/java/com/overlang/domain/word/entity/SelectedTextType.java
+++ b/backend/src/main/java/com/overlang/domain/word/entity/SelectedTextType.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.word.entity;
+
+public class SelectedTextType {
+}

--- a/backend/src/main/java/com/overlang/domain/word/entity/SelectedTextType.java
+++ b/backend/src/main/java/com/overlang/domain/word/entity/SelectedTextType.java
@@ -1,4 +1,6 @@
 package com.overlang.domain.word.entity;
 
-public class SelectedTextType {
+public enum SelectedTextType {
+  ORIGINAL, // 원문 문장에서 선택한 단어
+  TRANSLATION // 번역 문장에서 선택한 단어
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainService.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainService.java
@@ -1,0 +1,9 @@
+package com.overlang.domain.word.service;
+
+import com.overlang.api.dto.word.WordsExplainRequest;
+import com.overlang.api.dto.word.WordsExplainResponse;
+
+public interface WordsExplainService {
+
+  WordsExplainResponse explain(WordsExplainRequest request);
+}

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -1,0 +1,88 @@
+package com.overlang.domain.word.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.overlang.api.dto.word.WordsExplainRequest;
+import com.overlang.api.dto.word.WordsExplainResponse;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class WordsExplainServiceImpl implements WordsExplainService {
+
+  private final RestClient openAiRestClient;
+  private final ObjectMapper objectMapper;
+
+  @Value("${openai.model}")
+  private String model;
+
+  @Override
+  public WordsExplainResponse explain(WordsExplainRequest request) {
+    String prompt = createPrompt(request);
+
+    Map<String, Object> body =
+        Map.of(
+            "model", model,
+            "input", prompt,
+            "store", false);
+
+    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
+
+    String outputText = extractOutputText(response);
+
+    try {
+      WordExplainAiResult result = objectMapper.readValue(outputText, WordExplainAiResult.class);
+
+      return new WordsExplainResponse(request.word(), result.meaning(), result.relatedWords());
+
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("OpenAI 응답 파싱에 실패했습니다.", e);
+    }
+  }
+
+  private String createPrompt(WordsExplainRequest request) {
+    return """
+        사용자가 영상 자막에서 선택한 단어의 뜻과 관련 단어를 생성
+
+        선택 단어: %s
+        선택 위치: %s
+        원문 문장: %s
+        번역 문장: %s
+        원본 언어: %s
+        대상 언어: %s
+
+        규칙:
+        - meaning은 대상 언어로 작성
+        - relatedWords는 선택 단어와 의미적으로 관련 있는 단어 3개를 작성
+        - 설명 문장 없이 JSON만 반환
+
+        JSON 형식:
+        {
+          "meaning": "단어 뜻",
+          "relatedWords": ["관련 단어1", "관련 단어2", "관련 단어3"]
+        }
+        """
+        .formatted(
+            request.word(),
+            request.selectedTextType(),
+            request.originalSentence(),
+            request.translatedSentence(),
+            request.sourceLanguage(),
+            request.targetLanguage());
+  }
+
+  @SuppressWarnings("unchecked")
+  private String extractOutputText(Map response) {
+    List<Map<String, Object>> output = (List<Map<String, Object>>) response.get("output");
+    Map<String, Object> message = output.get(0);
+    List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
+    return (String) content.get(0).get("text");
+  }
+
+  private record WordExplainAiResult(String meaning, List<String> relatedWords) {}
+}

--- a/backend/src/main/java/com/overlang/global/auth/AuthInterceptor.java
+++ b/backend/src/main/java/com/overlang/global/auth/AuthInterceptor.java
@@ -22,6 +22,10 @@ public class AuthInterceptor implements HandlerInterceptor {
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
 
+    if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+      return true;
+    }
+
     String token = bearerTokenResolver.resolve(request);
     FirebaseUserInfo userInfo = firebaseTokenVerifier.verify(token);
 

--- a/backend/src/main/java/com/overlang/global/config/OpenAiConfig.java
+++ b/backend/src/main/java/com/overlang/global/config/OpenAiConfig.java
@@ -1,0 +1,19 @@
+package com.overlang.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class OpenAiConfig {
+
+  @Bean
+  public RestClient openAiRestClient(@Value("${openai.api-key}") String apiKey) {
+    return RestClient.builder()
+        .baseUrl("https://api.openai.com/v1")
+        .defaultHeader("Authorization", "Bearer " + apiKey)
+        .defaultHeader("Content-Type", "application/json")
+        .build();
+  }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -32,3 +32,7 @@ spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
 worker.secret=overlang-worker-secret
+
+# OpenAI
+openai.api-key=${OPENAI_API_KEY}
+openai.model=gpt-5.4-mini


### PR DESCRIPTION
## 작업 개요
- 클릭한 단어의 뜻과 관련 단어를 생성하는  Words Explain API를 구현

## 관련 이슈
- close #78

## 작업 내용
- `POST /api/v1/words/explain` API 구현
- 원문/번역문 단어 선택 구분을 위한 `SelectedTextType` enum 추가
- Words Explain Request/Response DTO 추가
- OpenAI API 연동을 위한 설정 및 RestClient 구성 추가
- 공용 OpenAI API Key 기반 단어 설명 생성 로직 구현
- 선택 단어의 뜻과 관련 단어 목록 반환 처리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="2334" height="442" alt="image" src="https://github.com/user-attachments/assets/66dcc512-1426-44a9-a4e2-84b4873abc59" />
<img width="2312" height="501" alt="image" src="https://github.com/user-attachments/assets/beae2f5f-3490-4cdd-a1f3-870705041dbc" />

## 기타 사항
- 발음 음성 재생은 BE에서 처리하지 않고 FE에서 브라우저 TTS로 처리