### PR TITLE
feat: project 수정, 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/ProjectController.java
+++ b/backend/src/main/java/com/overlang/api/controller/ProjectController.java
@@ -3,8 +3,11 @@ package com.overlang.api.controller;
 import com.overlang.api.dto.file.PresignedUrlResponse;
 import com.overlang.api.dto.project.ProjectCreateRequest;
 import com.overlang.api.dto.project.ProjectCreateResponse;
+import com.overlang.api.dto.project.ProjectDeleteResponse;
 import com.overlang.api.dto.project.ProjectDetailResponse;
 import com.overlang.api.dto.project.ProjectResponse;
+import com.overlang.api.dto.project.ProjectUpdateRequest;
+import com.overlang.api.dto.project.ProjectUpdateResponse;
 import com.overlang.domain.project.service.ProjectService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
@@ -50,6 +53,32 @@ public class ProjectController {
     Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
 
     ProjectDetailResponse response = projectService.getProject(memberId, projectId);
+    return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "프로젝트 수정")
+  @PatchMapping("/{projectId}")
+  public ApiResponse<ProjectUpdateResponse> updateProject(
+      @PathVariable Long projectId,
+      @Valid @RequestBody ProjectUpdateRequest request,
+      HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    ProjectUpdateResponse response = projectService.updateProject(memberId, projectId, request);
+
+    return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "프로젝트 삭제")
+  @DeleteMapping("/{projectId}")
+  public ApiResponse<ProjectDeleteResponse> deleteProject(
+      @PathVariable Long projectId, HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    ProjectDeleteResponse response = projectService.deleteProject(memberId, projectId);
+
     return ApiResponse.success(response);
   }
 

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectDeleteResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectDeleteResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.project;
+
+public record ProjectDeleteResponse(Long projectId, boolean deleted) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectUpdateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.overlang.api.dto.project;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProjectUpdateRequest(
+    @NotBlank(message = "프로젝트 제목은 비어 있을 수 없습니다.")
+        @Size(max = 100, message = "프로젝트 제목은 100자 이하로 입력해주세요.")
+        String title) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectUpdateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectUpdateResponse.java
@@ -1,0 +1,24 @@
+package com.overlang.api.dto.project;
+
+import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.entity.ProjectStatus;
+import com.overlang.domain.project.entity.SourceType;
+
+public record ProjectUpdateResponse(
+    Long projectId,
+    String title,
+    SourceType sourceType,
+    String sourceUrl,
+    String fileUrl,
+    ProjectStatus status) {
+
+  public static ProjectUpdateResponse from(Project project) {
+    return new ProjectUpdateResponse(
+        project.getId(),
+        project.getTitle(),
+        project.getSourceType(),
+        project.getSourceUrl(),
+        project.getFileUrl(),
+        project.getStatus());
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -19,6 +19,10 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
   boolean existsByIdAndProjectMemberId(Long jobId, Long memberId);
 
+  List<Job> findByProjectId(Long projectId);
+
+  void deleteByProjectId(Long projectId);
+
   @Query(
       """
       SELECT j

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -21,7 +21,9 @@ import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.repository.SegmentRepository;
+import com.overlang.domain.segment.repository.SegmentWordRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +39,7 @@ public class JobService {
   private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
   private final SegmentRepository segmentRepository;
+  private final SegmentWordRepository segmentWordRepository;
   private final OcrItemRepository ocrItemRepository;
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
@@ -237,7 +240,9 @@ public class JobService {
                         s.languageCode()))
             .toList();
 
-    segmentRepository.saveAll(segments);
+    List<Segment> savedSegments = segmentRepository.saveAll(segments);
+
+    createSegmentWords(savedSegments);
   }
 
   private void saveOcrItems(Job job, JobCallbackRequest request) {
@@ -261,5 +266,28 @@ public class JobService {
             .toList();
 
     ocrItemRepository.saveAll(ocrItems);
+  }
+
+  private void createSegmentWords(List<Segment> segments) {
+
+    List<SegmentWord> segmentWords =
+        segments.stream()
+            .flatMap(
+                segment -> {
+                  String[] words = segment.getText().split("\\s+");
+
+                  return java.util.stream.IntStream.range(0, words.length)
+                      .mapToObj(
+                          i ->
+                              new SegmentWord(
+                                  segment,
+                                  i + 1,
+                                  segment.getStartTime(),
+                                  segment.getEndTime(),
+                                  words[i]));
+                })
+            .toList();
+
+    segmentWordRepository.saveAll(segmentWords);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -2,14 +2,23 @@ package com.overlang.domain.project.service;
 
 import com.overlang.api.dto.project.ProjectCreateRequest;
 import com.overlang.api.dto.project.ProjectCreateResponse;
+import com.overlang.api.dto.project.ProjectDeleteResponse;
 import com.overlang.api.dto.project.ProjectDetailResponse;
 import com.overlang.api.dto.project.ProjectResponse;
+import com.overlang.api.dto.project.ProjectUpdateRequest;
+import com.overlang.api.dto.project.ProjectUpdateResponse;
 import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
+import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.domain.savedword.repository.SavedWordRepository;
+import com.overlang.domain.segment.repository.SegmentRepository;
+import com.overlang.domain.segment.repository.SegmentWordRepository;
 import com.overlang.global.util.YoutubeUrlUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +33,11 @@ public class ProjectService {
   private final ProjectRepository projectRepository;
   private final MemberRepository memberRepository;
   private final S3UploadService s3UploadService;
+  private final JobRepository jobRepository;
+  private final SegmentRepository segmentRepository;
+  private final SegmentWordRepository segmentWordRepository;
+  private final OcrItemRepository ocrItemRepository;
+  private final SavedWordRepository savedWordRepository;
 
   public ProjectCreateResponse createProject(Long memberId, ProjectCreateRequest request) {
     Member member =
@@ -107,5 +121,42 @@ public class ProjectService {
     }
 
     return s3UploadService.generatePresignedGetUrl(project.getFileKey());
+  }
+
+  public ProjectUpdateResponse updateProject(
+      Long memberId, Long projectId, ProjectUpdateRequest request) {
+
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+
+    project.updateTitle(request.title());
+
+    return ProjectUpdateResponse.from(project);
+  }
+
+  public ProjectDeleteResponse deleteProject(Long memberId, Long projectId) {
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+
+    List<Job> jobs = jobRepository.findByProjectId(projectId);
+
+    savedWordRepository.deleteByProjectId(projectId);
+
+    for (Job job : jobs) {
+      Long jobId = job.getId();
+
+      ocrItemRepository.deleteByJobId(jobId);
+      segmentWordRepository.deleteBySegmentJobId(jobId);
+      segmentRepository.deleteByJobId(jobId);
+    }
+
+    jobRepository.deleteByProjectId(projectId);
+    projectRepository.delete(project);
+
+    return new ProjectDeleteResponse(projectId, true);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -4,6 +4,9 @@ import com.overlang.domain.savedword.entity.SavedWord;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
 
@@ -12,4 +15,12 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
   List<SavedWord> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
   Optional<SavedWord> findByIdAndMemberId(Long id, Long memberId);
+
+  @Modifying
+  @Query(
+      """
+    DELETE FROM SavedWord sw
+    WHERE sw.segmentWord.segment.job.project.id = :projectId
+    """)
+  void deleteByProjectId(@Param("projectId") Long projectId);
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -3,4 +3,6 @@ package com.overlang.domain.segment.repository;
 import com.overlang.domain.segment.entity.SegmentWord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {}
+public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {
+  void deleteBySegmentJobId(Long jobId);
+}


### PR DESCRIPTION
## 작업 개요
- 프로젝트 수정/삭제 API 구현 및 프로젝트 삭제 시 연관 데이터 정리 로직 구현

## 관련 이슈
- close #88

## 작업 내용
- 프로젝트 제목 수정 API 구현 (`PATCH /api/v1/projects/{projectId}`)
- 프로젝트 삭제 API 구현 (`DELETE /api/v1/projects/{projectId}`)
- 프로젝트 삭제 시 연관 데이터 삭제 처리
  - saved_words
  - ocr_items
  - segment_words
  - segments
  - jobs
- SegmentWord 자동 생성 로직 추가
  - Worker callback 결과 저장 시 Segment 생성 후 SegmentWord 자동 생성
- SavedWord 정책 정리
  - 프로젝트 삭제 시 저장 단어도 함께 삭제되도록 구조 정리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항