### PR TITLE
feat: Segment, OCR 결과 응답 구조 확장

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
@@ -1,9 +1,13 @@
 package com.overlang.api.dto.job;
 
+import com.overlang.api.dto.ocr.BoundingBoxRequest;
+import com.overlang.api.dto.ocr.OcrStyleRequest;
+
 public record CallbackOcrItemRequest(
     Double startTime,
     Double endTime,
     String originText,
     String translatedText,
     BoundingBoxRequest boundingBox,
-    Double confidence) {}
+    Double confidence,
+    OcrStyleRequest style) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/BlurRegionRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/BlurRegionRequest.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record BlurRegionRequest(Double x, Double y, Double w, Double h) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/BlurRegionResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/BlurRegionResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record BlurRegionResponse(Double x, Double y, Double w, Double h) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/BoundingBoxRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/BoundingBoxRequest.java
@@ -1,3 +1,3 @@
-package com.overlang.api.dto.job;
+package com.overlang.api.dto.ocr;
 
 public record BoundingBoxRequest(Double x, Double y, Double w, Double h) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
@@ -10,7 +10,8 @@ public record OcrItemResponse(
     String originText,
     String translatedText,
     BoundingBoxResponse boundingBox,
-    Double confidence) {
+    Double confidence,
+    OcrStyleResponse style) {
 
   public static OcrItemResponse from(OcrItem ocrItem) {
     return new OcrItemResponse(
@@ -21,6 +22,12 @@ public record OcrItemResponse(
         ocrItem.getOriginText(),
         ocrItem.getTranslatedText(),
         new BoundingBoxResponse(ocrItem.getX(), ocrItem.getY(), ocrItem.getW(), ocrItem.getH()),
-        ocrItem.getConfidence());
+        ocrItem.getConfidence(),
+        new OcrStyleResponse(
+            ocrItem.getBackgroundColor(),
+            ocrItem.getDominantBackgroundColor(),
+            ocrItem.getTextColor(),
+            new BlurRegionResponse(
+                ocrItem.getBlurX(), ocrItem.getBlurY(), ocrItem.getBlurW(), ocrItem.getBlurH())));
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleRequest.java
@@ -1,0 +1,7 @@
+package com.overlang.api.dto.ocr;
+
+public record OcrStyleRequest(
+    String backgroundColor,
+    String dominantBackgroundColor,
+    String textColor,
+    BlurRegionRequest blurRegion) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleResponse.java
@@ -1,0 +1,7 @@
+package com.overlang.api.dto.ocr;
+
+public record OcrStyleResponse(
+    String backgroundColor,
+    String dominantBackgroundColor,
+    String textColor,
+    BlurRegionResponse blurRegion) {}

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
@@ -1,6 +1,7 @@
 package com.overlang.api.dto.segment;
 
 import com.overlang.domain.segment.entity.Segment;
+import java.util.List;
 
 public record SegmentResponse(
     Long segmentId,
@@ -10,9 +11,10 @@ public record SegmentResponse(
     Double endTime,
     String text,
     String translatedText,
-    String languageCode) {
+    String languageCode,
+    List<SegmentWordResponse> words) {
 
-  public static SegmentResponse from(Segment segment) {
+  public static SegmentResponse from(Segment segment, List<SegmentWordResponse> words) {
     return new SegmentResponse(
         segment.getId(),
         segment.getJob().getId(),
@@ -21,6 +23,7 @@ public record SegmentResponse(
         segment.getEndTime(),
         segment.getText(),
         segment.getTranslatedText(),
-        segment.getLanguageCode());
+        segment.getLanguageCode(),
+        words);
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
@@ -1,0 +1,16 @@
+package com.overlang.api.dto.segment;
+
+import com.overlang.domain.segment.entity.SegmentWord;
+
+public record SegmentWordResponse(
+    Long segmentWordId, Integer seq, String word, Double startTime, Double endTime) {
+
+  public static SegmentWordResponse from(SegmentWord segmentWord) {
+    return new SegmentWordResponse(
+        segmentWord.getId(),
+        segmentWord.getSeq(),
+        segmentWord.getWord(),
+        segmentWord.getStartTime(),
+        segmentWord.getEndTime());
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
+++ b/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
@@ -61,7 +61,14 @@ public class ResultCopyService {
                         item.getY(),
                         item.getW(),
                         item.getH(),
-                        item.getConfidence()))
+                        item.getConfidence(),
+                        item.getBackgroundColor(),
+                        item.getDominantBackgroundColor(),
+                        item.getTextColor(),
+                        item.getBlurX(),
+                        item.getBlurY(),
+                        item.getBlurW(),
+                        item.getBlurH()))
             .toList();
 
     ocrItemRepository.saveAll(copiedOcrItems);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -2,9 +2,11 @@ package com.overlang.domain.job.service;
 
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
+import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.segment.repository.SegmentRepository;
+import com.overlang.domain.segment.repository.SegmentWordRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JobResultService {
 
   private final SegmentRepository segmentRepository;
+  private final SegmentWordRepository segmentWordRepository;
   private final OcrItemRepository ocrItemRepository;
   private final JobRepository jobRepository;
 
@@ -22,7 +25,15 @@ public class JobResultService {
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
     validateJobOwner(jobId, memberId);
     return segmentRepository.findByJobIdOrderBySeqAsc(jobId).stream()
-        .map(SegmentResponse::from)
+        .map(
+            segment -> {
+              List<SegmentWordResponse> words =
+                  segmentWordRepository.findBySegmentIdOrderBySeqAsc(segment.getId()).stream()
+                      .map(SegmentWordResponse::from)
+                      .toList();
+
+              return SegmentResponse.from(segment, words);
+            })
         .toList();
   }
 

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -1,11 +1,8 @@
 package com.overlang.domain.job.service;
 
-import com.overlang.api.dto.job.JobCallbackRequest;
-import com.overlang.api.dto.job.JobCallbackResponse;
-import com.overlang.api.dto.job.JobCreateRequest;
-import com.overlang.api.dto.job.JobCreateResponse;
-import com.overlang.api.dto.job.JobDetailResponse;
-import com.overlang.api.dto.job.JobResponse;
+import com.overlang.api.dto.job.*;
+import com.overlang.api.dto.ocr.BlurRegionRequest;
+import com.overlang.api.dto.ocr.OcrStyleRequest;
 import com.overlang.domain.cache.service.ResultCacheService;
 import com.overlang.domain.cache.service.ResultCopyService;
 import com.overlang.domain.file.service.S3UploadService;
@@ -248,24 +245,33 @@ public class JobService {
   private void saveOcrItems(Job job, JobCallbackRequest request) {
     if (request.ocrItems() == null) return;
 
-    List<OcrItem> ocrItems =
-        request.ocrItems().stream()
-            .map(
-                o ->
-                    new OcrItem(
-                        job,
-                        o.startTime(),
-                        o.endTime(),
-                        o.originText(),
-                        o.translatedText(),
-                        o.boundingBox().x(),
-                        o.boundingBox().y(),
-                        o.boundingBox().w(),
-                        o.boundingBox().h(),
-                        o.confidence()))
-            .toList();
+    List<OcrItem> ocrItems = request.ocrItems().stream().map(o -> toOcrItem(job, o)).toList();
 
     ocrItemRepository.saveAll(ocrItems);
+  }
+
+  private OcrItem toOcrItem(Job job, CallbackOcrItemRequest o) {
+    OcrStyleRequest style = o.style();
+    BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
+
+    return new OcrItem(
+        job,
+        o.startTime(),
+        o.endTime(),
+        o.originText(),
+        o.translatedText(),
+        o.boundingBox().x(),
+        o.boundingBox().y(),
+        o.boundingBox().w(),
+        o.boundingBox().h(),
+        o.confidence(),
+        style != null ? style.backgroundColor() : null,
+        style != null ? style.dominantBackgroundColor() : null,
+        style != null ? style.textColor() : null,
+        blurRegion != null ? blurRegion.x() : null,
+        blurRegion != null ? blurRegion.y() : null,
+        blurRegion != null ? blurRegion.w() : null,
+        blurRegion != null ? blurRegion.h() : null);
   }
 
   private void createSegmentWords(List<Segment> segments) {

--- a/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
@@ -45,6 +45,27 @@ public class OcrItem extends BaseTimeEntity {
 
   @Column private Double confidence;
 
+  @Column(name = "background_color", length = 20)
+  private String backgroundColor;
+
+  @Column(name = "dominant_background_color", length = 20)
+  private String dominantBackgroundColor;
+
+  @Column(name = "text_color", length = 20)
+  private String textColor;
+
+  @Column(name = "blur_x")
+  private Double blurX;
+
+  @Column(name = "blur_y")
+  private Double blurY;
+
+  @Column(name = "blur_w")
+  private Double blurW;
+
+  @Column(name = "blur_h")
+  private Double blurH;
+
   public OcrItem(
       Job job,
       Double startTime,
@@ -55,7 +76,14 @@ public class OcrItem extends BaseTimeEntity {
       Double y,
       Double w,
       Double h,
-      Double confidence) {
+      Double confidence,
+      String backgroundColor,
+      String dominantBackgroundColor,
+      String textColor,
+      Double blurX,
+      Double blurY,
+      Double blurW,
+      Double blurH) {
     this.job = job;
     this.startTime = startTime;
     this.endTime = endTime;
@@ -66,5 +94,12 @@ public class OcrItem extends BaseTimeEntity {
     this.w = w;
     this.h = h;
     this.confidence = confidence;
+    this.backgroundColor = backgroundColor;
+    this.dominantBackgroundColor = dominantBackgroundColor;
+    this.textColor = textColor;
+    this.blurX = blurX;
+    this.blurY = blurY;
+    this.blurW = blurW;
+    this.blurH = blurH;
   }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -1,8 +1,11 @@
 package com.overlang.domain.segment.repository;
 
 import com.overlang.domain.segment.entity.SegmentWord;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {
+  List<SegmentWord> findBySegmentIdOrderBySeqAsc(Long segmentId);
+
   void deleteBySegmentJobId(Long jobId);
 }


### PR DESCRIPTION
## 작업 개요
OCR 결과 응답 구조 확장 및 SegmentWord 응답 정보 추가

## 관련 이슈
- close #90

## 작업 내용
- OCR style 관련 DTO 추가
  - OcrStyleRequest / OcrStyleResponse
  - BlurRegionRequest / BlurRegionResponse
- BoundingBoxRequest를 dto.ocr 패키지로 이동
- OcrItem 엔티티에 style 관련 필드 추가
  - backgroundColor
  - dominantBackgroundColor
  - textColor
  - blurX / blurY / blurW / blurH
- Worker callback 요청 구조에 style 정보 반영
- OCR 조회 응답에 style 정보 포함하도록 수정
- Segment 조회 응답에 SegmentWord 정보 추가
  - segmentWordId
  - word
  - seq
  - startTime / endTime

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- OCR style 및 blurRegion 응답 구조 검증 완료
- SegmentWord 포함 응답 기반 단어 저장 흐름 연동 가능