### PR TITLE
feat: 업로드 영상 삭제 시 S3 파일 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
+++ b/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -100,5 +101,16 @@ public class S3UploadService {
             .build();
 
     return s3Presigner.presignGetObject(presignRequest).url().toString();
+  }
+
+  public void deleteFile(String fileKey) {
+    if (fileKey == null || fileKey.isBlank()) {
+      return;
+    }
+
+    DeleteObjectRequest deleteObjectRequest =
+        DeleteObjectRequest.builder().bucket(bucket).key(fileKey).build();
+
+    s3Client.deleteObject(deleteObjectRequest);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -155,6 +155,9 @@ public class ProjectService {
     }
 
     jobRepository.deleteByProjectId(projectId);
+    if (project.getSourceType() == SourceType.UPLOAD) {
+      s3UploadService.deleteFile(project.getFileKey());
+    }
     projectRepository.delete(project);
 
     return new ProjectDeleteResponse(projectId, true);


### PR DESCRIPTION
## 작업 개요
- 프로젝트 삭제 시 업로드된 S3 영상 파일까지 함께 삭제되도록 기능 개선

## 관련 이슈
- close #96 

## 작업 내용
- S3UploadService에 파일 삭제 기능 추가
- 업로드 프로젝트 삭제 시 S3 파일 삭제 처리 추가
- sourceType 기반 업로드/유튜브 프로젝트 분기 처리
- 프로젝트 삭제 시 관련 데이터 삭제 흐름 유지
- Swagger를 통한 프로젝트 삭제 및 S3 파일 삭제 동작 테스트 완료

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
- 프로젝트 삭제 후 S3 파일 제거 및 DB 삭제 확인 완료
<img width="876" height="59" alt="image" src="https://github.com/user-attachments/assets/061d5221-f8ab-4b65-9aaa-b785ba81fbf0" />
<img width="1814" height="133" alt="image" src="https://github.com/user-attachments/assets/65ca8c64-7d71-4128-ac11-7106f2ecb736" />
<img width="1768" height="429" alt="image" src="https://github.com/user-attachments/assets/d52f6568-37fe-47b6-9ab2-5b746a4da7bf" />


## 기타 사항
- 업로드 프로젝트(`sourceType = UPLOAD`)만 S3 파일 삭제 수행
- 유튜브 프로젝트는 기존처럼 DB 데이터만 삭제