### PR TITLE
feat: Project 분석 재처리 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/JobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobController.java
@@ -4,6 +4,7 @@ import com.overlang.api.dto.job.JobCreateRequest;
 import com.overlang.api.dto.job.JobCreateResponse;
 import com.overlang.api.dto.job.JobDetailResponse;
 import com.overlang.api.dto.job.JobResponse;
+import com.overlang.api.dto.job.JobRetryResponse;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
@@ -54,6 +55,18 @@ public class JobController {
     Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
 
     JobDetailResponse response = jobService.getJobDetail(jobId, memberId);
+
+    return ApiResponse.success(response);
+  }
+
+  @Operation(summary = "분석 작업 재처리", description = "FAILED 상태의 최신 AI 작업을 동일 프로젝트 기준으로 재처리합니다.")
+  @PostMapping("/projects/{projectId}/jobs/retry")
+  public ApiResponse<JobRetryResponse> retryJob(
+      @PathVariable Long projectId, HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    JobRetryResponse response = jobService.retryJob(projectId, memberId);
 
     return ApiResponse.success(response);
   }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobRetryResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobRetryResponse.java
@@ -1,0 +1,7 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.project.entity.ProjectStatus;
+
+public record JobRetryResponse(
+    Long projectId, Long jobId, JobStatus jobStatus, ProjectStatus projectStatus, String message) {}

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -15,6 +15,8 @@ import org.springframework.data.repository.query.Param;
 public interface JobRepository extends JpaRepository<Job, Long> {
   List<Job> findByProjectIdOrderByCreatedAtDesc(Long projectId);
 
+  Optional<Job> findTopByProjectIdOrderByCreatedAtDesc(Long projectId);
+
   Optional<Job> findByIdAndProjectMemberId(Long jobId, Long memberId);
 
   boolean existsByIdAndProjectMemberId(Long jobId, Long memberId);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -8,6 +8,7 @@ import com.overlang.domain.cache.service.ResultCopyService;
 import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.CurrentStage;
 import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
 import com.overlang.domain.job.queue.JobQueuePayload;
 import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
@@ -154,6 +155,45 @@ public class JobService {
             .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
 
     return JobDetailResponse.from(job);
+  }
+
+  @Transactional
+  public JobRetryResponse retryJob(Long projectId, Long memberId) {
+    Project project =
+        projectRepository
+            .findByIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
+    Job latestJob =
+        jobRepository
+            .findTopByProjectIdOrderByCreatedAtDesc(project.getId())
+            .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
+
+    if (latestJob.getStatus() != JobStatus.FAILED) {
+      throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
+    }
+
+    Job retryJob =
+        new Job(
+            project,
+            latestJob.getJobType(),
+            latestJob.getSourceLanguage(),
+            latestJob.getTargetLanguage(),
+            latestJob.getTranslationProvider());
+
+    Job savedJob = jobRepository.save(retryJob);
+
+    project.updateStatus(ProjectStatus.PROCESSING);
+
+    JobQueuePayload payload = createQueuePayload(project, savedJob);
+    jobQueueProducer.enqueue(payload);
+
+    return new JobRetryResponse(
+        project.getId(),
+        savedJob.getId(),
+        savedJob.getStatus(),
+        project.getStatus(),
+        "분석 재처리 요청이 생성되었습니다.");
   }
 
   private void validateWorkerSecret(String requestWorkerSecret) {


### PR DESCRIPTION
## 작업 개요
FAILED 상태의 분석 Job을 재처리할 수 있는 API를 구현

## 관련 이슈
- close #98 

## 작업 내용
- 프로젝트 분석 재처리 API 추가
- `POST /api/v1/projects/{projectId}/jobs/retry` 엔드포인트 구현
- 최신 FAILED Job 조회 및 검증 로직 추가
- 기존 Job 설정 기반으로 새로운 Job 생성 처리
- Redis Queue 재등록 로직 추가
- 프로젝트 상태 PROCESSING 변경 처리
- 재처리 응답 DTO 추가

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 기존 FAILED Job은 유지하고, 재처리 시 새로운 Job을 생성하는 방식으로 구현
- FAILED 상태의 Job만 재처리 가능하도록 제한