### PR TITLE
feat: 프로필 이미지 업로드 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/AuthController.java
+++ b/backend/src/main/java/com/overlang/api/controller/AuthController.java
@@ -51,6 +51,10 @@ public class AuthController {
 
     return ApiResponse.success(
         new AuthMeResponse(
-            member.getId(), member.getFirebaseUid(), member.getEmail(), member.getName()));
+            member.getId(),
+            member.getFirebaseUid(),
+            member.getEmail(),
+            member.getName(),
+            member.getProfileImageUrl()));
   }
 }

--- a/backend/src/main/java/com/overlang/api/controller/MemberController.java
+++ b/backend/src/main/java/com/overlang/api/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.overlang.api.controller;
+
+import com.overlang.api.dto.member.ProfileImageUploadResponse;
+import com.overlang.domain.member.service.MemberService;
+import com.overlang.global.auth.AuthInterceptor;
+import com.overlang.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @Operation(summary = "프로필 이미지 업로드", description = "현재 로그인한 사용자의 프로필 이미지를 업로드합니다.")
+  @PostMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ApiResponse<ProfileImageUploadResponse> uploadProfileImage(
+      @RequestPart("file") MultipartFile file, HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    return ApiResponse.success(memberService.uploadProfileImage(memberId, file));
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/auth/AuthMeResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/auth/AuthMeResponse.java
@@ -1,3 +1,4 @@
 package com.overlang.api.dto.auth;
 
-public record AuthMeResponse(Long memberId, String firebaseUid, String email, String name) {}
+public record AuthMeResponse(
+    Long memberId, String firebaseUid, String email, String name, String profileImageUrl) {}

--- a/backend/src/main/java/com/overlang/api/dto/member/ProfileImageUploadResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/member/ProfileImageUploadResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.member;
+
+public record ProfileImageUploadResponse(String profileImageUrl) {}

--- a/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
+++ b/backend/src/main/java/com/overlang/domain/file/service/S3UploadService.java
@@ -19,13 +19,18 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 @Service
 public class S3UploadService {
 
-  private static final Set<String> ALLOWED_CONTENT_TYPES =
+  private static final Set<String> ALLOWED_VIDEO_CONTENT_TYPES =
       Set.of("video/mp4", "video/quicktime", "video/x-msvideo", "video/x-matroska");
 
+  private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES =
+      Set.of("image/jpeg", "image/png", "image/webp");
+
+  private static final long MAX_PROFILE_IMAGE_SIZE = 5 * 1024 * 1024;
+
   private final S3Client s3Client;
+  private final S3Presigner s3Presigner;
   private final String bucket;
   private final String region;
-  private final S3Presigner s3Presigner;
 
   public S3UploadService(
       S3Client s3Client,
@@ -39,51 +44,21 @@ public class S3UploadService {
   }
 
   public FileUploadResponse uploadVideo(MultipartFile file) {
-    validateFile(file);
+    validateVideoFile(file);
 
     String originalFilename = file.getOriginalFilename();
-    String extension = extractExtension(originalFilename);
-    String uniqueFileName = UUID.randomUUID() + extension;
-    String s3Key = "uploads/videos/" + uniqueFileName;
+    String s3Key = createS3Key("uploads/videos", originalFilename);
+    String fileUrl = uploadToS3(file, s3Key, "파일 업로드 중 오류가 발생했습니다.");
 
-    try {
-      PutObjectRequest putObjectRequest =
-          PutObjectRequest.builder()
-              .bucket(bucket)
-              .key(s3Key)
-              .contentType(file.getContentType())
-              .build();
-
-      s3Client.putObject(
-          putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-
-      String fileUrl = buildFileUrl(s3Key);
-
-      return new FileUploadResponse(originalFilename, s3Key, fileUrl);
-    } catch (IOException e) {
-      throw new IllegalArgumentException("파일 업로드 중 오류가 발생했습니다.");
-    }
+    return new FileUploadResponse(originalFilename, s3Key, fileUrl);
   }
 
-  private void validateFile(MultipartFile file) {
-    if (file == null || file.isEmpty()) {
-      throw new IllegalArgumentException("업로드할 파일이 없습니다.");
-    }
+  public String uploadProfileImage(MultipartFile file, Long memberId) {
+    validateProfileImage(file);
 
-    if (file.getContentType() == null || !ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
-      throw new IllegalArgumentException("지원하지 않는 영상 형식입니다.");
-    }
-  }
+    String s3Key = createS3Key("uploads/profiles/" + memberId, file.getOriginalFilename());
 
-  private String extractExtension(String fileName) {
-    if (fileName == null || !fileName.contains(".")) {
-      return "";
-    }
-    return fileName.substring(fileName.lastIndexOf("."));
-  }
-
-  private String buildFileUrl(String s3Key) {
-    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3Key;
+    return uploadToS3(file, s3Key, "프로필 이미지 업로드 중 오류가 발생했습니다.");
   }
 
   public String generatePresignedGetUrl(String fileKey) {
@@ -112,5 +87,85 @@ public class S3UploadService {
         DeleteObjectRequest.builder().bucket(bucket).key(fileKey).build();
 
     s3Client.deleteObject(deleteObjectRequest);
+  }
+
+  public void deleteFileByUrl(String fileUrl) {
+    if (fileUrl == null || fileUrl.isBlank()) {
+      return;
+    }
+
+    String prefix = buildS3UrlPrefix();
+
+    if (!fileUrl.startsWith(prefix)) {
+      return;
+    }
+
+    String fileKey = fileUrl.substring(prefix.length());
+    deleteFile(fileKey);
+  }
+
+  private String uploadToS3(MultipartFile file, String s3Key, String errorMessage) {
+    try {
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(s3Key)
+              .contentType(file.getContentType())
+              .build();
+
+      s3Client.putObject(
+          putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+      return buildFileUrl(s3Key);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(errorMessage);
+    }
+  }
+
+  private void validateVideoFile(MultipartFile file) {
+    validateNotEmpty(file, "업로드할 파일이 없습니다.");
+
+    if (!ALLOWED_VIDEO_CONTENT_TYPES.contains(file.getContentType())) {
+      throw new IllegalArgumentException("지원하지 않는 영상 형식입니다.");
+    }
+  }
+
+  private void validateProfileImage(MultipartFile file) {
+    validateNotEmpty(file, "업로드할 프로필 이미지가 없습니다.");
+
+    if (!ALLOWED_IMAGE_CONTENT_TYPES.contains(file.getContentType())) {
+      throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다.");
+    }
+
+    if (file.getSize() > MAX_PROFILE_IMAGE_SIZE) {
+      throw new IllegalArgumentException("프로필 이미지는 5MB 이하만 업로드할 수 있습니다.");
+    }
+  }
+
+  private void validateNotEmpty(MultipartFile file, String message) {
+    if (file == null || file.isEmpty() || file.getContentType() == null) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  private String createS3Key(String directory, String originalFilename) {
+    String extension = extractExtension(originalFilename);
+    return directory + "/" + UUID.randomUUID() + extension;
+  }
+
+  private String extractExtension(String fileName) {
+    if (fileName == null || !fileName.contains(".")) {
+      return "";
+    }
+
+    return fileName.substring(fileName.lastIndexOf("."));
+  }
+
+  private String buildFileUrl(String s3Key) {
+    return buildS3UrlPrefix() + s3Key;
+  }
+
+  private String buildS3UrlPrefix() {
+    return "https://" + bucket + ".s3." + region + ".amazonaws.com/";
   }
 }

--- a/backend/src/main/java/com/overlang/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/overlang/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.overlang.domain.member.service;
 
+import com.overlang.api.dto.member.ProfileImageUploadResponse;
+import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
 import com.overlang.global.auth.UnauthorizedException;
@@ -7,12 +9,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final S3UploadService s3UploadService;
 
   public record MemberWithStatus(Member member, boolean isNewMember) {}
 
@@ -53,5 +57,25 @@ public class MemberService {
 
   private String defaultName(String email) {
     return email.split("@")[0];
+  }
+
+  @Transactional
+  public ProfileImageUploadResponse uploadProfileImage(Long memberId, MultipartFile file) {
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new UnauthorizedException("Member not found"));
+
+    String oldProfileImageUrl = member.getProfileImageUrl();
+
+    String newProfileImageUrl = s3UploadService.uploadProfileImage(file, memberId);
+
+    member.updateProfileImage(newProfileImageUrl);
+
+    if (oldProfileImageUrl != null && !oldProfileImageUrl.isBlank()) {
+      s3UploadService.deleteFileByUrl(oldProfileImageUrl);
+    }
+
+    return new ProfileImageUploadResponse(newProfileImageUrl);
   }
 }


### PR DESCRIPTION
## 작업 개요
- 사용자 프로필 이미지 업로드 기능 구현

## 관련 이슈
- close #100

## 작업 내용
- `POST /api/v1/members/me/profile-image` API 추가
- multipart/form-data 기반 프로필 이미지 업로드 처리
- 프로필 이미지 S3 업로드 로직 추가
- 이미지 파일 형식 및 크기 검증 추가
- 프로필 이미지 변경 시 기존 S3 이미지 삭제 처리
- Member.profileImageUrl 업데이트 처리
- `/auth/me` 응답에 profileImageUrl 필드 추가
- 프로필 이미지 경로(`uploads/profiles/*`) public read 정책 적용

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="2388" height="365" alt="image" src="https://github.com/user-attachments/assets/c1a1a931-0b86-4592-aafd-89ffa7dcd202" />
<img width="1379" height="208" alt="image" src="https://github.com/user-attachments/assets/7e2ff863-509a-4576-82a9-6770ecaa95d8" />
<img width="2169" height="187" alt="image" src="https://github.com/user-attachments/assets/53adc734-4343-4a07-a5cd-6d0c8922ae3e" />

## 기타 사항
- 영상 파일은 기존과 동일하게 private + presigned URL 방식 유지
- 프로필 이미지만 public read 접근 허용