### PR TITLE
feat: 원문/번역문 SegmentWord 구조 확장

### DIFF
--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -20,8 +20,10 @@ import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -320,20 +322,46 @@ public class JobService {
         segments.stream()
             .flatMap(
                 segment -> {
-                  String[] words = segment.getText().split("\\s+");
+                  List<SegmentWord> words = new ArrayList<>();
 
-                  return java.util.stream.IntStream.range(0, words.length)
-                      .mapToObj(
-                          i ->
-                              new SegmentWord(
-                                  segment,
-                                  i + 1,
-                                  segment.getStartTime(),
-                                  segment.getEndTime(),
-                                  words[i]));
+                  // ORIGINAL words
+                  if (segment.getText() != null && !segment.getText().isBlank()) {
+
+                    String[] originalWords = segment.getText().split("\\s+");
+
+                    for (int i = 0; i < originalWords.length; i++) {
+                      words.add(
+                          new SegmentWord(
+                              segment,
+                              i + 1,
+                              segment.getStartTime(),
+                              segment.getEndTime(),
+                              originalWords[i],
+                              SegmentWordType.ORIGINAL));
+                    }
+                  }
+
+                  // TRANSLATION words
+                  if (segment.getTranslatedText() != null
+                      && !segment.getTranslatedText().isBlank()) {
+
+                    String[] translatedWords = segment.getTranslatedText().split("\\s+");
+
+                    for (int i = 0; i < translatedWords.length; i++) {
+                      words.add(
+                          new SegmentWord(
+                              segment,
+                              i + 1,
+                              segment.getStartTime(),
+                              segment.getEndTime(),
+                              translatedWords[i],
+                              SegmentWordType.TRANSLATION));
+                    }
+                  }
+
+                  return words.stream();
                 })
             .toList();
-
     segmentWordRepository.saveAll(segmentWords);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/entity/SegmentWord.java
+++ b/backend/src/main/java/com/overlang/domain/segment/entity/SegmentWord.java
@@ -29,11 +29,22 @@ public class SegmentWord {
   @Column(nullable = false, length = 255)
   private String word;
 
-  public SegmentWord(Segment segment, Integer seq, Double startTime, Double endTime, String word) {
+  @Enumerated(EnumType.STRING)
+  @Column(name = "word_type", nullable = false, length = 20)
+  private SegmentWordType wordType;
+
+  public SegmentWord(
+      Segment segment,
+      Integer seq,
+      Double startTime,
+      Double endTime,
+      String word,
+      SegmentWordType wordType) {
     this.segment = segment;
     this.seq = seq;
     this.startTime = startTime;
     this.endTime = endTime;
     this.word = word;
+    this.wordType = wordType;
   }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/entity/SegmentWordType.java
+++ b/backend/src/main/java/com/overlang/domain/segment/entity/SegmentWordType.java
@@ -1,0 +1,6 @@
+package com.overlang.domain.segment.entity;
+
+public enum SegmentWordType {
+  ORIGINAL,
+  TRANSLATION
+}

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -1,6 +1,7 @@
 package com.overlang.domain.segment.repository;
 
 import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,10 @@ public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> 
   List<SegmentWord> findBySegmentIdOrderBySeqAsc(Long segmentId);
 
   void deleteBySegmentJobId(Long jobId);
+
+  List<SegmentWord> findBySegmentIdIn(List<Long> segmentIds);
+
+  List<SegmentWord> findBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
+
+  void deleteBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
 }


### PR DESCRIPTION
## 작업 개요
- 원문(text)과 번역문(translatedText) 기반 SegmentWord를 모두 저장할 수 있도록 SegmentWord 구조 확장

## 관련 이슈
- close #102

## 작업 내용
- SegmentWordType enum 추가
  - ORIGINAL
  - TRANSLATION
- segment_words 테이블에 word_type 컬럼 추가
- SegmentWord Entity에 wordType 필드 추가
- 기존 ORIGINAL SegmentWord 생성 로직 유지
- translatedText 기반 TRANSLATION SegmentWord 생성 로직 추가
- TRANSLATION SegmentWord의 startTime/endTime은 Segment 구간 시간 사용
- Worker callback 저장 흐름에서 TRANSLATION SegmentWord 생성 반영
- SegmentWord Repository 메서드 추가
- segment_words 테이블 정의서 수정

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [X] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
- 없음

## 기타 사항
- 기존 데이터는 개발 환경 기준 재생성하여 반영