### PR TITLE
feat: Segment 조회 및 SavedWord 구조 개선

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
@@ -1,12 +1,14 @@
 package com.overlang.api.dto.savedword;
 
 import com.overlang.domain.savedword.entity.SavedWord;
+import com.overlang.domain.word.entity.SelectedTextType;
 import java.time.Instant;
 
 public record SavedWordResponse(
     Long savedWordId,
     Long segmentWordId,
     String word,
+    SelectedTextType selectedTextType,
     String meaning,
     String contextMeaning,
     String memo,
@@ -28,6 +30,7 @@ public record SavedWordResponse(
         savedWord.getId(),
         segmentWord.getId(),
         segmentWord.getWord(),
+        SelectedTextType.valueOf(segmentWord.getWordType().name()),
         savedWord.getMeaning(),
         savedWord.getContextMeaning(),
         savedWord.getMemo(),

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
@@ -12,9 +12,13 @@ public record SegmentResponse(
     String text,
     String translatedText,
     String languageCode,
-    List<SegmentWordResponse> words) {
+    List<SegmentWordResponse> originalWords,
+    List<SegmentWordResponse> translatedWords) {
 
-  public static SegmentResponse from(Segment segment, List<SegmentWordResponse> words) {
+  public static SegmentResponse from(
+      Segment segment,
+      List<SegmentWordResponse> originalWords,
+      List<SegmentWordResponse> translatedWords) {
     return new SegmentResponse(
         segment.getId(),
         segment.getJob().getId(),
@@ -24,6 +28,7 @@ public record SegmentResponse(
         segment.getText(),
         segment.getTranslatedText(),
         segment.getLanguageCode(),
-        words);
+        originalWords,
+        translatedWords);
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
@@ -1,15 +1,22 @@
 package com.overlang.api.dto.segment;
 
 import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.word.entity.SelectedTextType;
 
 public record SegmentWordResponse(
-    Long segmentWordId, Integer seq, String word, Double startTime, Double endTime) {
+    Long segmentWordId,
+    Integer seq,
+    String word,
+    SelectedTextType selectedTextType,
+    Double startTime,
+    Double endTime) {
 
   public static SegmentWordResponse from(SegmentWord segmentWord) {
     return new SegmentWordResponse(
         segmentWord.getId(),
         segmentWord.getSeq(),
         segmentWord.getWord(),
+        SelectedTextType.valueOf(segmentWord.getWordType().name()),
         segmentWord.getStartTime(),
         segmentWord.getEndTime());
   }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -5,9 +5,14 @@ import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,24 +29,52 @@ public class JobResultService {
   @Transactional(readOnly = true)
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
     validateJobOwner(jobId, memberId);
-    return segmentRepository.findByJobIdOrderBySeqAsc(jobId).stream()
-        .map(
-            segment -> {
-              List<SegmentWordResponse> words =
-                  segmentWordRepository.findBySegmentIdOrderBySeqAsc(segment.getId()).stream()
-                      .map(SegmentWordResponse::from)
-                      .toList();
 
-              return SegmentResponse.from(segment, words);
-            })
-        .toList();
+    List<Segment> segments = segmentRepository.findByJobIdOrderBySeqAsc(jobId);
+
+    if (segments.isEmpty()) {
+      return List.of();
+    }
+
+    Map<Long, List<SegmentWord>> wordsBySegmentId = getWordsBySegmentId(segments);
+
+    return segments.stream().map(segment -> toSegmentResponse(segment, wordsBySegmentId)).toList();
   }
 
   @Transactional(readOnly = true)
   public List<OcrItemResponse> getOcrItems(Long jobId, Long memberId) {
     validateJobOwner(jobId, memberId);
+
     return ocrItemRepository.findByJobIdOrderByStartTimeAsc(jobId).stream()
         .map(OcrItemResponse::from)
+        .toList();
+  }
+
+  private Map<Long, List<SegmentWord>> getWordsBySegmentId(List<Segment> segments) {
+    List<Long> segmentIds = segments.stream().map(Segment::getId).toList();
+
+    return segmentWordRepository.findBySegmentIdIn(segmentIds).stream()
+        .collect(Collectors.groupingBy(segmentWord -> segmentWord.getSegment().getId()));
+  }
+
+  private SegmentResponse toSegmentResponse(
+      Segment segment, Map<Long, List<SegmentWord>> wordsBySegmentId) {
+    List<SegmentWord> segmentWords = wordsBySegmentId.getOrDefault(segment.getId(), List.of());
+
+    List<SegmentWordResponse> originalWords =
+        toSegmentWordResponses(segmentWords, SegmentWordType.ORIGINAL);
+
+    List<SegmentWordResponse> translatedWords =
+        toSegmentWordResponses(segmentWords, SegmentWordType.TRANSLATION);
+
+    return SegmentResponse.from(segment, originalWords, translatedWords);
+  }
+
+  private List<SegmentWordResponse> toSegmentWordResponses(
+      List<SegmentWord> segmentWords, SegmentWordType wordType) {
+    return segmentWords.stream()
+        .filter(segmentWord -> segmentWord.getWordType() == wordType)
+        .map(SegmentWordResponse::from)
         .toList();
   }
 


### PR DESCRIPTION
## 작업 개요
- Segment 조회 응답 구조를 originalWords / translatedWords 기반으로 확장하고, 번역문 단어도 segmentWordId 기반으로 저장 가능하도록 SavedWord 구조를 개선

## 관련 이슈
- close #106 

## 작업 내용
- SegmentWordResponse DTO에 selectedTextType 추가
- SegmentResponse 구조 변경
  - words 제거
  - originalWords 추가
  - translatedWords 추가
- Segment 조회 Service에서 SegmentWord를 wordType 기준으로 분리 처리
- SegmentWords 일괄 조회 기반으로 조회 로직 개선
- 번역문 SegmentWord도 segmentWordId 기반으로 저장 가능하도록 SavedWord 저장 구조 확인
- SavedWord 응답에 selectedTextType 추가
- Segment 조회 및 SavedWord 저장 Swagger 응답 구조 확인

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- Segment 조회 응답 구조가 변경
  - 기존: words
  - 변경: originalWords, translatedWords
- 번역문 단어 클릭/저장은 translatedWords[].segmentWordId 사용