### PR TITLE
feat: WordExplain EXPRESSION 매핑 기능 추가

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -33,41 +33,58 @@ public class InternalJobController {
                               name = "콜백 예시",
                               value =
                                   """
-                {
-                  "jobId": 2,
-                  "status": "COMPLETED",
-                  "progress": 100,
-                  "currentStage": "FINALIZING",
-                  "segments": [
-                    {
-                      "seq": 1,
-                      "startTime": 0.0,
-                      "endTime": 2.0,
-                      "text": "Hello",
-                      "translatedText": "안녕",
-                      "languageCode": "en"
-                    }
-                  ],
-                  "ocrItems": [
-                    {
-                      "startTime": 1.0,
-                      "endTime": 2.0,
-                      "originText": "EXIT",
-                      "translatedText": "출구",
-                      "boundingBox": {
-                        "x": 0.1,
-                        "y": 0.2,
-                        "w": 0.3,
-                        "h": 0.4
-                      },
-                      "confidence": 0.95
-                    }
-                  ],
-                  "learningData": null,
-                  "errorCode": null,
-                  "errorMessage": null
-                }
-                """)))
+                        {
+                          "jobId": 2,
+                          "status": "COMPLETED",
+                          "progress": 100,
+                          "currentStage": "FINALIZING",
+                          "segments": [
+                            {
+                              "seq": 1,
+                              "startTime": 0.0,
+                              "endTime": 2.0,
+                              "text": "Hello",
+                              "translatedText": "안녕",
+                              "languageCode": "en"
+                            }
+                          ],
+                          "ocrItems": [
+                            {
+                              "startTime": 1.0,
+                              "endTime": 2.0,
+                              "originText": "EXIT",
+                              "translatedText": "출구",
+                              "boundingBox": {
+                                "x": 0.1,
+                                "y": 0.2,
+                                "w": 0.3,
+                                "h": 0.4
+                              },
+                              "confidence": 0.95
+                            }
+                          ],
+                          "learningData": {
+                            "contents": [
+                              {
+                                "contentType": "SUMMARY",
+                                "title": "Summary",
+                                "content": "이 영상은 영어 표현을 설명합니다.",
+                                "startTime": null,
+                                "endTime": null
+                              },
+                              {
+                                "contentType": "EXPRESSION",
+                                "title": "step by step",
+                                "content": "직역: 단계별로. 실제 의미: 차근차근.",
+                                "startTime": 0,
+                                "endTime": 2
+                              }
+                            ]
+                          },
+                          "errorCode": null,
+                          "errorMessage": null
+                        }
+                        """)))
           @org.springframework.web.bind.annotation.RequestBody
           JobCallbackRequest request) {
 

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningContentRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningContentRequest.java
@@ -1,0 +1,10 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.learning.entity.LearningContentType;
+
+public record CallbackLearningContentRequest(
+    LearningContentType contentType,
+    String title,
+    String content,
+    Double startTime,
+    Double endTime) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningDataRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningDataRequest.java
@@ -1,0 +1,5 @@
+package com.overlang.api.dto.job;
+
+import java.util.List;
+
+public record CallbackLearningDataRequest(List<CallbackLearningContentRequest> contents) {}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobCallbackRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobCallbackRequest.java
@@ -11,6 +11,6 @@ public record JobCallbackRequest(
     CurrentStage currentStage,
     List<CallbackSegmentRequest> segments,
     List<CallbackOcrItemRequest> ocrItems,
-    Object learningData,
+    CallbackLearningDataRequest learningData,
     String errorCode,
     String errorMessage) {}

--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
@@ -1,12 +1,14 @@
 package com.overlang.api.dto.savedword;
 
 import com.overlang.domain.savedword.entity.SavedWord;
+import com.overlang.domain.word.entity.SelectedTextType;
 import java.time.Instant;
 
 public record SavedWordResponse(
     Long savedWordId,
     Long segmentWordId,
     String word,
+    SelectedTextType selectedTextType,
     String meaning,
     String contextMeaning,
     String memo,
@@ -28,6 +30,7 @@ public record SavedWordResponse(
         savedWord.getId(),
         segmentWord.getId(),
         segmentWord.getWord(),
+        SelectedTextType.valueOf(segmentWord.getWordType().name()),
         savedWord.getMeaning(),
         savedWord.getContextMeaning(),
         savedWord.getMemo(),

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentResponse.java
@@ -12,9 +12,13 @@ public record SegmentResponse(
     String text,
     String translatedText,
     String languageCode,
-    List<SegmentWordResponse> words) {
+    List<SegmentWordResponse> originalWords,
+    List<SegmentWordResponse> translatedWords) {
 
-  public static SegmentResponse from(Segment segment, List<SegmentWordResponse> words) {
+  public static SegmentResponse from(
+      Segment segment,
+      List<SegmentWordResponse> originalWords,
+      List<SegmentWordResponse> translatedWords) {
     return new SegmentResponse(
         segment.getId(),
         segment.getJob().getId(),
@@ -24,6 +28,7 @@ public record SegmentResponse(
         segment.getText(),
         segment.getTranslatedText(),
         segment.getLanguageCode(),
-        words);
+        originalWords,
+        translatedWords);
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/segment/SegmentWordResponse.java
@@ -1,15 +1,22 @@
 package com.overlang.api.dto.segment;
 
 import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.word.entity.SelectedTextType;
 
 public record SegmentWordResponse(
-    Long segmentWordId, Integer seq, String word, Double startTime, Double endTime) {
+    Long segmentWordId,
+    Integer seq,
+    String word,
+    SelectedTextType selectedTextType,
+    Double startTime,
+    Double endTime) {
 
   public static SegmentWordResponse from(SegmentWord segmentWord) {
     return new SegmentWordResponse(
         segmentWord.getId(),
         segmentWord.getSeq(),
         segmentWord.getWord(),
+        SelectedTextType.valueOf(segmentWord.getWordType().name()),
         segmentWord.getStartTime(),
         segmentWord.getEndTime());
   }

--- a/backend/src/main/java/com/overlang/api/dto/word/WordsExplainRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/word/WordsExplainRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record WordsExplainRequest(
+    @NotNull(message = "세그먼트 ID는 필수입니다.") Long segmentId,
     @NotBlank(message = "단어는 필수입니다.") String word,
     @NotNull(message = "선택한 텍스트 타입은 필수입니다.") SelectedTextType selectedTextType,
     @NotBlank(message = "원문 문장은 필수입니다.") String originalSentence,

--- a/backend/src/main/java/com/overlang/api/dto/word/WordsExplainResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/word/WordsExplainResponse.java
@@ -2,4 +2,5 @@ package com.overlang.api.dto.word;
 
 import java.util.List;
 
-public record WordsExplainResponse(String word, String meaning, List<String> relatedWords) {}
+public record WordsExplainResponse(
+    String word, String meaning, List<String> relatedWords, boolean matchedExpression) {}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -5,9 +5,14 @@ import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,24 +29,52 @@ public class JobResultService {
   @Transactional(readOnly = true)
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
     validateJobOwner(jobId, memberId);
-    return segmentRepository.findByJobIdOrderBySeqAsc(jobId).stream()
-        .map(
-            segment -> {
-              List<SegmentWordResponse> words =
-                  segmentWordRepository.findBySegmentIdOrderBySeqAsc(segment.getId()).stream()
-                      .map(SegmentWordResponse::from)
-                      .toList();
 
-              return SegmentResponse.from(segment, words);
-            })
-        .toList();
+    List<Segment> segments = segmentRepository.findByJobIdOrderBySeqAsc(jobId);
+
+    if (segments.isEmpty()) {
+      return List.of();
+    }
+
+    Map<Long, List<SegmentWord>> wordsBySegmentId = getWordsBySegmentId(segments);
+
+    return segments.stream().map(segment -> toSegmentResponse(segment, wordsBySegmentId)).toList();
   }
 
   @Transactional(readOnly = true)
   public List<OcrItemResponse> getOcrItems(Long jobId, Long memberId) {
     validateJobOwner(jobId, memberId);
+
     return ocrItemRepository.findByJobIdOrderByStartTimeAsc(jobId).stream()
         .map(OcrItemResponse::from)
+        .toList();
+  }
+
+  private Map<Long, List<SegmentWord>> getWordsBySegmentId(List<Segment> segments) {
+    List<Long> segmentIds = segments.stream().map(Segment::getId).toList();
+
+    return segmentWordRepository.findBySegmentIdIn(segmentIds).stream()
+        .collect(Collectors.groupingBy(segmentWord -> segmentWord.getSegment().getId()));
+  }
+
+  private SegmentResponse toSegmentResponse(
+      Segment segment, Map<Long, List<SegmentWord>> wordsBySegmentId) {
+    List<SegmentWord> segmentWords = wordsBySegmentId.getOrDefault(segment.getId(), List.of());
+
+    List<SegmentWordResponse> originalWords =
+        toSegmentWordResponses(segmentWords, SegmentWordType.ORIGINAL);
+
+    List<SegmentWordResponse> translatedWords =
+        toSegmentWordResponses(segmentWords, SegmentWordType.TRANSLATION);
+
+    return SegmentResponse.from(segment, originalWords, translatedWords);
+  }
+
+  private List<SegmentWordResponse> toSegmentWordResponses(
+      List<SegmentWord> segmentWords, SegmentWordType wordType) {
+    return segmentWords.stream()
+        .filter(segmentWord -> segmentWord.getWordType() == wordType)
+        .map(SegmentWordResponse::from)
         .toList();
   }
 

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -12,6 +12,8 @@ import com.overlang.domain.job.entity.JobStatus;
 import com.overlang.domain.job.queue.JobQueuePayload;
 import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.learning.entity.LearningContent;
+import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.entity.OcrItem;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.project.entity.Project;
@@ -34,6 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class JobService {
 
+  private static final String WORD_SPLIT_REGEX = "\\s+";
+
   private final ProjectRepository projectRepository;
   private final JobRepository jobRepository;
   private final S3UploadService s3UploadService;
@@ -43,6 +47,7 @@ public class JobService {
   private final OcrItemRepository ocrItemRepository;
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
+  private final LearningContentRepository learningContentRepository;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -246,13 +251,16 @@ public class JobService {
     deletePreviousResults(job.getId());
     saveSegments(job, request);
     saveOcrItems(job, request);
+    saveLearningContents(job, request.learningData());
 
     job.getProject().markCompleted();
   }
 
   private void deletePreviousResults(Long jobId) {
+    segmentWordRepository.deleteBySegmentJobId(jobId);
     segmentRepository.deleteByJobId(jobId);
     ocrItemRepository.deleteByJobId(jobId);
+    learningContentRepository.deleteByJobId(jobId);
   }
 
   private void handleFailedCallback(Job job, JobCallbackRequest request) {
@@ -317,51 +325,59 @@ public class JobService {
   }
 
   private void createSegmentWords(List<Segment> segments) {
-
     List<SegmentWord> segmentWords =
-        segments.stream()
-            .flatMap(
-                segment -> {
-                  List<SegmentWord> words = new ArrayList<>();
+        segments.stream().flatMap(segment -> createSegmentWords(segment).stream()).toList();
 
-                  // ORIGINAL words
-                  if (segment.getText() != null && !segment.getText().isBlank()) {
-
-                    String[] originalWords = segment.getText().split("\\s+");
-
-                    for (int i = 0; i < originalWords.length; i++) {
-                      words.add(
-                          new SegmentWord(
-                              segment,
-                              i + 1,
-                              segment.getStartTime(),
-                              segment.getEndTime(),
-                              originalWords[i],
-                              SegmentWordType.ORIGINAL));
-                    }
-                  }
-
-                  // TRANSLATION words
-                  if (segment.getTranslatedText() != null
-                      && !segment.getTranslatedText().isBlank()) {
-
-                    String[] translatedWords = segment.getTranslatedText().split("\\s+");
-
-                    for (int i = 0; i < translatedWords.length; i++) {
-                      words.add(
-                          new SegmentWord(
-                              segment,
-                              i + 1,
-                              segment.getStartTime(),
-                              segment.getEndTime(),
-                              translatedWords[i],
-                              SegmentWordType.TRANSLATION));
-                    }
-                  }
-
-                  return words.stream();
-                })
-            .toList();
     segmentWordRepository.saveAll(segmentWords);
+  }
+
+  private List<SegmentWord> createSegmentWords(Segment segment) {
+    List<SegmentWord> words = new ArrayList<>();
+
+    words.addAll(createSegmentWords(segment, segment.getText(), SegmentWordType.ORIGINAL));
+
+    words.addAll(
+        createSegmentWords(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
+
+    return words;
+  }
+
+  private List<SegmentWord> createSegmentWords(
+      Segment segment, String text, SegmentWordType wordType) {
+    if (text == null || text.isBlank()) {
+      return List.of();
+    }
+
+    String[] words = text.split(WORD_SPLIT_REGEX);
+    List<SegmentWord> segmentWords = new ArrayList<>();
+
+    for (int i = 0; i < words.length; i++) {
+      segmentWords.add(
+          new SegmentWord(
+              segment, i + 1, segment.getStartTime(), segment.getEndTime(), words[i], wordType));
+    }
+
+    return segmentWords;
+  }
+
+  private void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {
+    if (learningData == null || learningData.contents() == null) {
+      return;
+    }
+
+    List<LearningContent> learningContents =
+        learningData.contents().stream()
+            .map(
+                content ->
+                    new LearningContent(
+                        job,
+                        content.contentType(),
+                        content.title(),
+                        content.content(),
+                        content.startTime(),
+                        content.endTime()))
+            .toList();
+
+    learningContentRepository.saveAll(learningContents);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/learning/repository/LearningContentRepository.java
+++ b/backend/src/main/java/com/overlang/domain/learning/repository/LearningContentRepository.java
@@ -1,0 +1,12 @@
+package com.overlang.domain.learning.repository;
+
+import com.overlang.domain.learning.entity.LearningContent;
+import com.overlang.domain.learning.entity.LearningContentType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningContentRepository extends JpaRepository<LearningContent, Long> {
+  List<LearningContent> findByJobIdAndContentType(Long jobId, LearningContentType contentType);
+
+  void deleteByJobId(Long jobId);
+}

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -4,8 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.overlang.api.dto.word.WordsExplainRequest;
 import com.overlang.api.dto.word.WordsExplainResponse;
+import com.overlang.domain.learning.entity.LearningContent;
+import com.overlang.domain.learning.entity.LearningContentType;
+import com.overlang.domain.learning.repository.LearningContentRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.repository.SegmentRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,14 +22,31 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class WordsExplainServiceImpl implements WordsExplainService {
 
+  private static final String WORD_SPLIT_REGEX = "\\s+";
+  private static final String NON_WORD_REGEX = "[^\\p{IsAlphabetic}\\p{IsDigit}\\s]";
+
   private final RestClient openAiRestClient;
   private final ObjectMapper objectMapper;
+  private final SegmentRepository segmentRepository;
+  private final LearningContentRepository learningContentRepository;
 
   @Value("${openai.model}")
   private String model;
 
   @Override
   public WordsExplainResponse explain(WordsExplainRequest request) {
+    Optional<LearningContent> matchedExpression = findMatchedExpression(request);
+
+    if (matchedExpression.isPresent()) {
+      LearningContent expression = matchedExpression.get();
+
+      List<String> relatedWords =
+          generateRelatedWords(expression.getTitle(), getSelectedTextLanguage(request));
+
+      return new WordsExplainResponse(
+          expression.getTitle(), expression.getContent(), relatedWords, true);
+    }
+
     String prompt = createPrompt(request);
 
     Map<String, Object> body =
@@ -38,7 +62,8 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     try {
       WordExplainAiResult result = objectMapper.readValue(outputText, WordExplainAiResult.class);
 
-      return new WordsExplainResponse(request.word(), result.meaning(), result.relatedWords());
+      return new WordsExplainResponse(
+          request.word(), result.meaning(), result.relatedWords(), false);
 
     } catch (JsonProcessingException e) {
       throw new RuntimeException("OpenAI 응답 파싱에 실패했습니다.", e);
@@ -47,33 +72,38 @@ public class WordsExplainServiceImpl implements WordsExplainService {
 
   private String createPrompt(WordsExplainRequest request) {
     return """
-        사용자가 영상 자막에서 선택한 단어의 뜻과 관련 단어를 생성
+      사용자가 영상 자막에서 선택한 단어의 뜻과 관련 단어를 생성
 
-        선택 단어: %s
-        선택 위치: %s
-        원문 문장: %s
-        번역 문장: %s
-        원본 언어: %s
-        대상 언어: %s
+      선택 단어: %s
+      선택 위치: %s
+      원문 문장: %s
+      번역 문장: %s
+      원본 언어: %s
+      대상 언어: %s
+      선택 단어 언어: %s
 
-        규칙:
-        - meaning은 대상 언어로 작성
-        - relatedWords는 선택 단어와 의미적으로 관련 있는 단어 3개를 작성
-        - 설명 문장 없이 JSON만 반환
+      규칙:
+      - meaning은 선택 단어 언어로 작성
+      - relatedWords는 선택 단어 언어로 작성
+      - relatedWords는 선택 단어와 유사한 의미의 단어 또는 표현 3개를 작성
+      - relatedWords는 사전식 유의어 또는 비슷한 의미의 표현 위주로 작성
+      - 단순 연관어(카테고리, 분야 단어)는 제외
+      - 설명 문장 없이 JSON만 반환
 
-        JSON 형식:
-        {
-          "meaning": "단어 뜻",
-          "relatedWords": ["관련 단어1", "관련 단어2", "관련 단어3"]
-        }
-        """
+      JSON 형식:
+      {
+        "meaning": "단어 뜻",
+        "relatedWords": ["관련 단어1", "관련 단어2", "관련 단어3"]
+      }
+      """
         .formatted(
             request.word(),
             request.selectedTextType(),
             request.originalSentence(),
             request.translatedSentence(),
             request.sourceLanguage(),
-            request.targetLanguage());
+            request.targetLanguage(),
+            getSelectedTextLanguage(request));
   }
 
   @SuppressWarnings("unchecked")
@@ -85,4 +115,96 @@ public class WordsExplainServiceImpl implements WordsExplainService {
   }
 
   private record WordExplainAiResult(String meaning, List<String> relatedWords) {}
+
+  private record RelatedWordsResult(List<String> relatedWords) {}
+
+  private Optional<LearningContent> findMatchedExpression(WordsExplainRequest request) {
+    Segment segment =
+        segmentRepository
+            .findById(request.segmentId())
+            .orElseThrow(() -> new IllegalArgumentException("세그먼트를 찾을 수 없습니다."));
+
+    String clickedWord = normalize(request.word());
+
+    return learningContentRepository
+        .findByJobIdAndContentType(segment.getJob().getId(), LearningContentType.EXPRESSION)
+        .stream()
+        .filter(expression -> overlapsSegmentTime(segment, expression))
+        .filter(expression -> containsClickedWord(expression.getTitle(), clickedWord))
+        .max(Comparator.comparingInt(expression -> expression.getTitle().length()));
+  }
+
+  private boolean overlapsSegmentTime(Segment segment, LearningContent expression) {
+    if (expression.getStartTime() == null || expression.getEndTime() == null) {
+      return false;
+    }
+
+    return expression.getStartTime() <= segment.getEndTime()
+        && expression.getEndTime() >= segment.getStartTime();
+  }
+
+  private boolean containsClickedWord(String expressionTitle, String clickedWord) {
+    if (expressionTitle == null || clickedWord == null || clickedWord.isBlank()) {
+      return false;
+    }
+
+    String normalizedTitle = normalize(expressionTitle);
+
+    return List.of(normalizedTitle.split(WORD_SPLIT_REGEX)).contains(clickedWord);
+  }
+
+  private String normalize(String value) {
+    if (value == null) {
+      return "";
+    }
+
+    return value.toLowerCase().replaceAll(NON_WORD_REGEX, "").trim();
+  }
+
+  private List<String> generateRelatedWords(String expression, String targetLanguage) {
+
+    String prompt =
+        """
+            다음 표현과 관련 있는 단어 3개를 생성하세요.
+
+            표현: %s
+            출력 언어: %s
+
+            규칙:
+            - 설명 없이 JSON만 반환
+            - relatedWords는 문자열 배열
+
+            JSON 형식:
+            {
+              "relatedWords": ["단어1", "단어2", "단어3"]
+            }
+            """
+            .formatted(expression, targetLanguage);
+
+    Map<String, Object> body =
+        Map.of(
+            "model", model,
+            "input", prompt,
+            "store", false);
+
+    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
+
+    String outputText = extractOutputText(response);
+
+    try {
+      RelatedWordsResult result = objectMapper.readValue(outputText, RelatedWordsResult.class);
+
+      return result.relatedWords();
+
+    } catch (JsonProcessingException e) {
+      return List.of();
+    }
+  }
+
+  private String getSelectedTextLanguage(WordsExplainRequest request) {
+    return switch (request.selectedTextType()) {
+      case ORIGINAL -> request.sourceLanguage();
+      case TRANSLATION -> request.targetLanguage();
+    };
+  }
 }


### PR DESCRIPTION
## 작업 개요
- Word Explain API에 EXPRESSION 기반 관용/숙어 자동 매핑 기능 추가

## 관련 이슈
- close #108 

## 작업 내용
- Worker callback의 learningData.contents 저장 로직 추가
- learning_contents에 SUMMARY / EXPRESSION 데이터 저장 처리
- WordExplainRequest에 segmentId 추가
- segmentId 기준 Segment 조회 로직 추가
- jobId 기준 EXPRESSION learning_contents 조회 로직 추가
- 현재 segment 시간 범위와 겹치는 EXPRESSION 후보 필터링
- expression.title에 clickedWord가 포함되는지 검사
- EXPRESSION이 여러 개 매칭될 경우 가장 긴 title 우선 적용
- EXPRESSION 매칭 성공 시 Worker가 저장한 expression content 기반 응답 반환
- EXPRESSION 매칭 시 relatedWords만 OpenAI로 생성
- EXPRESSION 매칭 실패 시 기존 단일 단어 설명 로직 유지
- WordExplainResponse에 matchedExpression 필드 추가
- 원문/번역문 선택 타입에 따라 meaning, relatedWords 언어 분리 처리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- WordExplain API 요청에 segmentId가 추가
- EXPRESSION 매칭 성공 시 matchedExpression=true가 반환
- 일반 단어 설명은 matchedExpression=false로 반환