### PR TITLE
feat: 번역문 수정 및 TRANSLATION SegmentWord 재생성 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/ProjectController.java
+++ b/backend/src/main/java/com/overlang/api/controller/ProjectController.java
@@ -1,13 +1,7 @@
 package com.overlang.api.controller;
 
 import com.overlang.api.dto.file.PresignedUrlResponse;
-import com.overlang.api.dto.project.ProjectCreateRequest;
-import com.overlang.api.dto.project.ProjectCreateResponse;
-import com.overlang.api.dto.project.ProjectDeleteResponse;
-import com.overlang.api.dto.project.ProjectDetailResponse;
-import com.overlang.api.dto.project.ProjectResponse;
-import com.overlang.api.dto.project.ProjectUpdateRequest;
-import com.overlang.api.dto.project.ProjectUpdateResponse;
+import com.overlang.api.dto.project.*;
 import com.overlang.domain.project.service.ProjectService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
@@ -91,5 +85,17 @@ public class ProjectController {
     String presignedUrl = projectService.getVideoPresignedUrl(memberId, projectId);
 
     return ApiResponse.success(new PresignedUrlResponse(presignedUrl));
+  }
+
+  @Operation(summary = "번역문 수정 저장", description = "사용자가 수정한 번역문을 저장하고 TRANSLATION SegmentWord를 재생성합니다.")
+  @PatchMapping("/{projectId}/results")
+  public ApiResponse<ProjectResultUpdateResponse> updateProjectResults(
+          @PathVariable Long projectId,
+          @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId,
+          @Valid @RequestBody ProjectResultUpdateRequest request) {
+    ProjectResultUpdateResponse response =
+            projectService.updateProjectResults(projectId, memberId, request);
+
+    return ApiResponse.success(response);
   }
 }

--- a/backend/src/main/java/com/overlang/api/controller/ProjectController.java
+++ b/backend/src/main/java/com/overlang/api/controller/ProjectController.java
@@ -87,14 +87,16 @@ public class ProjectController {
     return ApiResponse.success(new PresignedUrlResponse(presignedUrl));
   }
 
-  @Operation(summary = "번역문 수정 저장", description = "사용자가 수정한 번역문을 저장하고 TRANSLATION SegmentWord를 재생성합니다.")
+  @Operation(
+      summary = "번역문 수정 저장",
+      description = "사용자가 수정한 번역문을 저장하고 TRANSLATION SegmentWord를 재생성합니다.")
   @PatchMapping("/{projectId}/results")
   public ApiResponse<ProjectResultUpdateResponse> updateProjectResults(
-          @PathVariable Long projectId,
-          @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId,
-          @Valid @RequestBody ProjectResultUpdateRequest request) {
+      @PathVariable Long projectId,
+      @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId,
+      @Valid @RequestBody ProjectResultUpdateRequest request) {
     ProjectResultUpdateResponse response =
-            projectService.updateProjectResults(projectId, memberId, request);
+        projectService.updateProjectResults(projectId, memberId, request);
 
     return ApiResponse.success(response);
   }

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentResponse.java
@@ -1,0 +1,17 @@
+package com.overlang.api.dto.project;
+
+import com.overlang.domain.segment.entity.SegmentWordType;
+import java.util.List;
+
+public record ProjectResultSegmentResponse(
+        Long segmentId,
+        String translatedText,
+        List<ProjectResultSegmentWordResponse> translatedWords) {
+
+    public record ProjectResultSegmentWordResponse(
+            Long segmentWordId,
+            String word,
+            SegmentWordType wordType,
+            Double startTime,
+            Double endTime) {}
+}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentResponse.java
@@ -4,14 +4,12 @@ import com.overlang.domain.segment.entity.SegmentWordType;
 import java.util.List;
 
 public record ProjectResultSegmentResponse(
-        Long segmentId,
-        String translatedText,
-        List<ProjectResultSegmentWordResponse> translatedWords) {
+    Long segmentId, String translatedText, List<ProjectResultSegmentWordResponse> translatedWords) {
 
-    public record ProjectResultSegmentWordResponse(
-            Long segmentWordId,
-            String word,
-            SegmentWordType wordType,
-            Double startTime,
-            Double endTime) {}
+  public record ProjectResultSegmentWordResponse(
+      Long segmentWordId,
+      String word,
+      SegmentWordType wordType,
+      Double startTime,
+      Double endTime) {}
 }

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentUpdateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentUpdateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ProjectResultSegmentUpdateRequest(
-        @NotNull(message = "segmentId는 필수입니다.") Long segmentId,
-        @NotBlank(message = "translatedText는 필수입니다.") String translatedText) {}
+    @NotNull(message = "segmentId는 필수입니다.") Long segmentId,
+    @NotBlank(message = "translatedText는 필수입니다.") String translatedText) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentUpdateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultSegmentUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.overlang.api.dto.project;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProjectResultSegmentUpdateRequest(
+        @NotNull(message = "segmentId는 필수입니다.") Long segmentId,
+        @NotBlank(message = "translatedText는 필수입니다.") String translatedText) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateRequest.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record ProjectResultUpdateRequest(
-        @Valid @NotEmpty(message = "segments는 비어 있을 수 없습니다.")
+    @Valid @NotEmpty(message = "segments는 비어 있을 수 없습니다.")
         List<ProjectResultSegmentUpdateRequest> segments) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.overlang.api.dto.project;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record ProjectResultUpdateRequest(
+        @Valid @NotEmpty(message = "segments는 비어 있을 수 없습니다.")
+        List<ProjectResultSegmentUpdateRequest> segments) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateResponse.java
@@ -3,5 +3,4 @@ package com.overlang.api.dto.project;
 import java.util.List;
 
 public record ProjectResultUpdateResponse(
-        Long projectId,
-        List<ProjectResultSegmentResponse> segments) {}
+    Long projectId, List<ProjectResultSegmentResponse> segments) {}

--- a/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/project/ProjectResultUpdateResponse.java
@@ -1,0 +1,7 @@
+package com.overlang.api.dto.project;
+
+import java.util.List;
+
+public record ProjectResultUpdateResponse(
+        Long projectId,
+        List<ProjectResultSegmentResponse> segments) {}

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -11,10 +11,16 @@ import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
+import com.overlang.domain.segment.entity.Segment;
+import com.overlang.domain.segment.entity.SegmentWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
 import com.overlang.global.util.YoutubeUrlUtils;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class ProjectService {
+
+  private static final String WORD_SPLIT_REGEX = "\\s+";
 
   private final ProjectRepository projectRepository;
   private final MemberRepository memberRepository;
@@ -156,12 +164,108 @@ public class ProjectService {
 
     return new ProjectDeleteResponse(projectId, true);
   }
+
   @Transactional
   public ProjectResultUpdateResponse updateProjectResults(
-          Long projectId,
-          Long memberId,
-          ProjectResultUpdateRequest request) {
-    throw new UnsupportedOperationException("아직 구현되지 않았습니다.");
+      Long projectId, Long memberId, ProjectResultUpdateRequest request) {
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
+    List<Long> segmentIds =
+        request.segments().stream().map(ProjectResultSegmentUpdateRequest::segmentId).toList();
+
+    List<Segment> segments = segmentRepository.findByIdIn(segmentIds);
+
+    if (segments.size() != segmentIds.size()) {
+      throw new IllegalArgumentException("존재하지 않는 segment가 포함되어 있습니다.");
+    }
+    boolean hasInvalidSegment =
+        segments.stream()
+            .anyMatch(segment -> !segment.getJob().getProject().getId().equals(projectId));
+
+    if (hasInvalidSegment) {
+      throw new IllegalArgumentException("다른 프로젝트의 segment는 수정할 수 없습니다.");
+    }
+    savedWordRepository.deleteBySegmentIdsAndWordType(segmentIds, SegmentWordType.TRANSLATION);
+
+    segmentWordRepository.deleteBySegmentIdInAndWordType(segmentIds, SegmentWordType.TRANSLATION);
+    Map<Long, String> translatedTextBySegmentId =
+        request.segments().stream()
+            .collect(
+                Collectors.toMap(
+                    ProjectResultSegmentUpdateRequest::segmentId,
+                    ProjectResultSegmentUpdateRequest::translatedText));
+
+    segments.forEach(
+        segment -> segment.updateTranslatedText(translatedTextBySegmentId.get(segment.getId())));
+    List<SegmentWord> newTranslatedWords = createTranslationSegmentWords(segments);
+
+    List<SegmentWord> savedTranslatedWords = segmentWordRepository.saveAll(newTranslatedWords);
+
+    Map<Long, List<ProjectResultSegmentResponse.ProjectResultSegmentWordResponse>>
+        translatedWordsBySegmentId =
+            savedTranslatedWords.stream()
+                .collect(
+                    Collectors.groupingBy(
+                        segmentWord -> segmentWord.getSegment().getId(),
+                        Collectors.mapping(
+                            segmentWord ->
+                                new ProjectResultSegmentResponse.ProjectResultSegmentWordResponse(
+                                    segmentWord.getId(),
+                                    segmentWord.getWord(),
+                                    segmentWord.getWordType(),
+                                    segmentWord.getStartTime(),
+                                    segmentWord.getEndTime()),
+                            Collectors.toList())));
+
+    List<ProjectResultSegmentResponse> segmentResponses =
+        segments.stream()
+            .map(
+                segment ->
+                    new ProjectResultSegmentResponse(
+                        segment.getId(),
+                        segment.getTranslatedText(),
+                        translatedWordsBySegmentId.getOrDefault(segment.getId(), List.of())))
+            .toList();
+
+    return new ProjectResultUpdateResponse(project.getId(), segmentResponses);
   }
 
+  private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {
+    return projectRepository
+        .findByIdAndMemberId(projectId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+  }
+
+  private List<SegmentWord> createTranslationSegmentWords(List<Segment> segments) {
+    List<SegmentWord> segmentWords = new ArrayList<>();
+
+    for (Segment segment : segments) {
+      String translatedText = segment.getTranslatedText();
+
+      if (translatedText == null || translatedText.isBlank()) {
+        continue;
+      }
+
+      String[] words = translatedText.split(WORD_SPLIT_REGEX);
+
+      int seq = 1;
+
+      for (String rawWord : words) {
+        String cleanedWord = rawWord.replaceAll("^[\\p{Punct}]+|[\\p{Punct}]+$", "");
+
+        if (cleanedWord.isBlank()) {
+          continue;
+        }
+
+        segmentWords.add(
+            new SegmentWord(
+                segment,
+                seq++,
+                segment.getStartTime(),
+                segment.getEndTime(),
+                cleanedWord,
+                SegmentWordType.TRANSLATION));
+      }
+    }
+    return segmentWords;
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -1,12 +1,6 @@
 package com.overlang.domain.project.service;
 
-import com.overlang.api.dto.project.ProjectCreateRequest;
-import com.overlang.api.dto.project.ProjectCreateResponse;
-import com.overlang.api.dto.project.ProjectDeleteResponse;
-import com.overlang.api.dto.project.ProjectDetailResponse;
-import com.overlang.api.dto.project.ProjectResponse;
-import com.overlang.api.dto.project.ProjectUpdateRequest;
-import com.overlang.api.dto.project.ProjectUpdateResponse;
+import com.overlang.api.dto.project.*;
 import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
@@ -162,4 +156,12 @@ public class ProjectService {
 
     return new ProjectDeleteResponse(projectId, true);
   }
+  @Transactional
+  public ProjectResultUpdateResponse updateProjectResults(
+          Long projectId,
+          Long memberId,
+          ProjectResultUpdateRequest request) {
+    throw new UnsupportedOperationException("아직 구현되지 않았습니다.");
+  }
+
 }

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -1,6 +1,7 @@
 package com.overlang.domain.savedword.repository;
 
 import com.overlang.domain.savedword.entity.SavedWord;
+import com.overlang.domain.segment.entity.SegmentWordType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,18 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
     WHERE sw.segmentWord.segment.job.project.id = :projectId
     """)
   void deleteByProjectId(@Param("projectId") Long projectId);
+
+  @Modifying
+  @Query(
+      """
+          DELETE FROM SavedWord sw
+          WHERE sw.segmentWord.id IN (
+            SELECT segmentWord.id
+            FROM SegmentWord segmentWord
+            WHERE segmentWord.segment.id IN :segmentIds
+              AND segmentWord.wordType = :wordType
+          )
+          """)
+  void deleteBySegmentIdsAndWordType(
+      @Param("segmentIds") List<Long> segmentIds, @Param("wordType") SegmentWordType wordType);
 }

--- a/backend/src/main/java/com/overlang/domain/segment/entity/Segment.java
+++ b/backend/src/main/java/com/overlang/domain/segment/entity/Segment.java
@@ -53,4 +53,8 @@ public class Segment extends BaseTimeEntity {
     this.translatedText = translatedText;
     this.languageCode = languageCode;
   }
+
+  public void updateTranslatedText(String translatedText) {
+    this.translatedText = translatedText;
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentRepository.java
@@ -8,4 +8,6 @@ public interface SegmentRepository extends JpaRepository<Segment, Long> {
   List<Segment> findByJobIdOrderBySeqAsc(Long jobId);
 
   void deleteByJobId(Long jobId);
+
+  List<Segment> findByIdIn(List<Long> segmentIds);
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -4,6 +4,7 @@ import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {
   List<SegmentWord> findBySegmentIdOrderBySeqAsc(Long segmentId);
@@ -15,4 +16,7 @@ public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> 
   List<SegmentWord> findBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
 
   void deleteBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
+
+  @Modifying
+  void deleteBySegmentIdInAndWordType(List<Long> segmentIds, SegmentWordType wordType);
 }


### PR DESCRIPTION
## 작업 개요
- 사용자가 수정한 번역문(translatedText)을 저장할 수 있는 API를 구현
- 번역문 수정 시 TRANSLATION SegmentWord를 새 번역문 기준으로 재생성하고
- 기존 TRANSLATION SavedWord를 삭제하여 데이터 정합성을 유지하도록 구현

## 관련 이슈
- close #110

## 작업 내용
- `PATCH /api/v1/projects/{projectId}/results` API 추가
- translatedText 수정 기능 구현
- 프로젝트 권한 및 segment 소속 검증 구현
- 기존 TRANSLATION SavedWord 삭제 처리
- 기존 TRANSLATION SegmentWord 삭제 처리
- 수정된 translatedText 기준 TRANSLATION SegmentWord 재생성 구현
- ORIGINAL SegmentWord 및 ORIGINAL SavedWord 유지 처리
- 수정 결과 응답에 translatedWords 반환 추가
- 번역문 단어 생성 시 문장부호 제거 전처리 추가

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- TRANSLATION 데이터만 재생성하고 ORIGINAL 데이터는 유지하도록 구현
- TRANSLATION SegmentWord의 startTime/endTime은 해당 segment 구간 시간을 사용
- SavedWord FK 문제 방지를 위해 TRANSLATION SavedWord를 먼저 삭제 후 SegmentWord를 삭제하도록 처리