### PR TITLE
feat: 학습 콘텐츠 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/JobResultController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobResultController.java
@@ -1,8 +1,10 @@
 package com.overlang.api.controller;
 
+import com.overlang.api.dto.learning.LearningContentsResponse;
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.domain.job.service.JobResultService;
+import com.overlang.domain.learning.service.LearningContentService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class JobResultController {
 
   private final JobResultService jobResultService;
+  private final LearningContentService learningContentService;
 
   @Operation(summary = "세그먼트 조회", description = "특정 Job의 STT 세그먼트를 조회합니다.")
   @GetMapping("/{jobId}/segments")
@@ -30,6 +33,19 @@ public class JobResultController {
   public ApiResponse<List<OcrItemResponse>> getOcrItems(
       @PathVariable Long jobId, @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId) {
     List<OcrItemResponse> result = jobResultService.getOcrItems(jobId, memberId);
+    return ApiResponse.success(result);
+  }
+
+  @Operation(
+      summary = "학습 콘텐츠 조회",
+      description =
+          "AI 분석 결과로 생성된 학습 콘텐츠를 조회합니다. " + "SUMMARY, KEYWORD, EXPRESSION 타입별로 분리하여 반환합니다.")
+  @GetMapping("/{jobId}/learning-contents")
+  public ApiResponse<LearningContentsResponse> getLearningContents(
+      @PathVariable Long jobId, @RequestAttribute(AuthInterceptor.AUTH_MEMBER_ID) Long memberId) {
+
+    LearningContentsResponse result = learningContentService.getLearningContents(jobId, memberId);
+
     return ApiResponse.success(result);
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/learning/LearningContentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/learning/LearningContentResponse.java
@@ -1,0 +1,16 @@
+package com.overlang.api.dto.learning;
+
+import com.overlang.domain.learning.entity.LearningContent;
+
+public record LearningContentResponse(
+    Long learningContentId, String title, String content, Double startTime, Double endTime) {
+
+  public static LearningContentResponse from(LearningContent learningContent) {
+    return new LearningContentResponse(
+        learningContent.getId(),
+        learningContent.getTitle(),
+        learningContent.getContent(),
+        learningContent.getStartTime(),
+        learningContent.getEndTime());
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/learning/LearningContentsResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/learning/LearningContentsResponse.java
@@ -1,0 +1,9 @@
+package com.overlang.api.dto.learning;
+
+import java.util.List;
+
+public record LearningContentsResponse(
+    Long jobId,
+    LearningContentResponse summary,
+    List<LearningContentResponse> keywords,
+    List<LearningContentResponse> expressions) {}

--- a/backend/src/main/java/com/overlang/domain/learning/repository/LearningContentRepository.java
+++ b/backend/src/main/java/com/overlang/domain/learning/repository/LearningContentRepository.java
@@ -9,4 +9,6 @@ public interface LearningContentRepository extends JpaRepository<LearningContent
   List<LearningContent> findByJobIdAndContentType(Long jobId, LearningContentType contentType);
 
   void deleteByJobId(Long jobId);
+
+  List<LearningContent> findByJobIdOrderByStartTimeAscIdAsc(Long jobId);
 }

--- a/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
+++ b/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
@@ -1,0 +1,56 @@
+package com.overlang.domain.learning.service;
+
+import com.overlang.api.dto.learning.LearningContentResponse;
+import com.overlang.api.dto.learning.LearningContentsResponse;
+import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.learning.entity.LearningContent;
+import com.overlang.domain.learning.entity.LearningContentType;
+import com.overlang.domain.learning.repository.LearningContentRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LearningContentService {
+
+  private final LearningContentRepository learningContentRepository;
+  private final JobRepository jobRepository;
+
+  @Transactional(readOnly = true)
+  public LearningContentsResponse getLearningContents(Long jobId, Long memberId) {
+    validateJobOwner(jobId, memberId);
+
+    List<LearningContent> learningContents =
+        learningContentRepository.findByJobIdOrderByStartTimeAscIdAsc(jobId);
+
+    Map<LearningContentType, List<LearningContentResponse>> contentsByType =
+        learningContents.stream()
+            .collect(
+                Collectors.groupingBy(
+                    LearningContent::getContentType,
+                    Collectors.mapping(LearningContentResponse::from, Collectors.toList())));
+
+    LearningContentResponse summary =
+        contentsByType.getOrDefault(LearningContentType.SUMMARY, List.of()).stream()
+            .findFirst()
+            .orElse(null);
+
+    List<LearningContentResponse> keywords =
+        contentsByType.getOrDefault(LearningContentType.KEYWORD, List.of());
+
+    List<LearningContentResponse> expressions =
+        contentsByType.getOrDefault(LearningContentType.EXPRESSION, List.of());
+
+    return new LearningContentsResponse(jobId, summary, keywords, expressions);
+  }
+
+  private void validateJobOwner(Long jobId, Long memberId) {
+    if (!jobRepository.existsByIdAndProjectMemberId(jobId, memberId)) {
+      throw new IllegalArgumentException("작업을 찾을 수 없습니다.");
+    }
+  }
+}


### PR DESCRIPTION
## 작업 개요
- AI 분석 결과로 생성된 학습 콘텐츠 조회 API 구현

## 관련 이슈
- close #116 

## 작업 내용
- `GET /api/v1/jobs/{jobId}/learning-contents` API 추가
- LearningContent 조회용 DTO 생성
- Job 소유자 권한 검증 구현
- learning_contents 조회 로직 구현
- SUMMARY / KEYWORD / EXPRESSION 타입별 분리 응답 구현
- LearningContent 정렬 처리(startTime ASC, id ASC)
- 빈 학습 데이터 응답 처리 구현

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- Worker callback에서 저장된 learning_contents 데이터를 기반으로 조회
- 응답은 SUMMARY / KEYWORD / EXPRESSION 타입별로 분리하여 반환