### PR TITLE
feat: EXPRESSION 원문/번역문 타입 구분 지원

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -64,22 +64,32 @@ public class InternalJobController {
                             }
                           ],
                           "learningData": {
-                            "contents": [
-                              {
-                                "contentType": "SUMMARY",
-                                "title": "Summary",
-                                "content": "이 영상은 영어 표현을 설명합니다.",
-                                "startTime": null,
-                                "endTime": null
-                              },
-                              {
-                                "contentType": "EXPRESSION",
-                                "title": "step by step",
-                                "content": "직역: 단계별로. 실제 의미: 차근차근.",
-                                "startTime": 0,
-                                "endTime": 2
-                              }
-                            ]
+                           "contents": [
+                                               {
+                                                 "contentType": "SUMMARY",
+                                                 "textType": "ORIGINAL",
+                                                 "title": "Summary",
+                                                 "content": "이 영상은 영어 표현을 설명합니다.",
+                                                 "startTime": null,
+                                                 "endTime": null
+                                               },
+                                               {
+                                                 "contentType": "KEYWORD",
+                                                 "textType": "ORIGINAL",
+                                                 "title": "subtitles",
+                                                 "content": "자막",
+                                                 "startTime": 0,
+                                                 "endTime": 2
+                                               },
+                                               {
+                                                 "contentType": "EXPRESSION",
+                                                 "textType": "ORIGINAL",
+                                                 "title": "step by step",
+                                                 "content": "직역: 단계별로. 실제 의미: 차근차근.",
+                                                 "startTime": 0,
+                                                 "endTime": 2
+                                               }
+                                             ]
                           },
                           "errorCode": null,
                           "errorMessage": null

--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningContentRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackLearningContentRequest.java
@@ -1,9 +1,11 @@
 package com.overlang.api.dto.job;
 
 import com.overlang.domain.learning.entity.LearningContentType;
+import com.overlang.domain.word.entity.SelectedTextType;
 
 public record CallbackLearningContentRequest(
     LearningContentType contentType,
+    SelectedTextType textType,
     String title,
     String content,
     Double startTime,

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -20,6 +20,7 @@ import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
@@ -48,6 +49,7 @@ public class JobService {
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
   private final LearningContentRepository learningContentRepository;
+  private final SavedWordRepository savedWordRepository;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -257,6 +259,7 @@ public class JobService {
   }
 
   private void deletePreviousResults(Long jobId) {
+    savedWordRepository.deleteByJobId(jobId);
     segmentWordRepository.deleteBySegmentJobId(jobId);
     segmentRepository.deleteByJobId(jobId);
     ocrItemRepository.deleteByJobId(jobId);
@@ -372,6 +375,7 @@ public class JobService {
                     new LearningContent(
                         job,
                         content.contentType(),
+                        content.textType(),
                         content.title(),
                         content.content(),
                         content.startTime(),

--- a/backend/src/main/java/com/overlang/domain/learning/entity/LearningContent.java
+++ b/backend/src/main/java/com/overlang/domain/learning/entity/LearningContent.java
@@ -2,6 +2,7 @@ package com.overlang.domain.learning.entity;
 
 import com.overlang.domain.common.BaseTimeEntity;
 import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.word.entity.SelectedTextType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,6 +24,10 @@ public class LearningContent extends BaseTimeEntity {
   @Column(name = "content_type", nullable = false, length = 50)
   private LearningContentType contentType;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "text_type", nullable = false, length = 30)
+  private SelectedTextType textType;
+
   @Column(length = 255)
   private String title;
 
@@ -38,12 +43,14 @@ public class LearningContent extends BaseTimeEntity {
   public LearningContent(
       Job job,
       LearningContentType contentType,
+      SelectedTextType textType,
       String title,
       String content,
       Double startTime,
       Double endTime) {
     this.job = job;
     this.contentType = contentType;
+    this.textType = textType;
     this.title = title;
     this.content = content;
     this.startTime = startTime;

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -20,7 +20,8 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
   @Modifying
   @Query(
       """
-    DELETE FROM SavedWord sw
+
+                  DELETE FROM SavedWord sw
     WHERE sw.segmentWord.segment.job.project.id = :projectId
     """)
   void deleteByProjectId(@Param("projectId") Long projectId);
@@ -38,4 +39,12 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
           """)
   void deleteBySegmentIdsAndWordType(
       @Param("segmentIds") List<Long> segmentIds, @Param("wordType") SegmentWordType wordType);
+
+  @Modifying
+  @Query(
+      """
+          DELETE FROM SavedWord sw
+          WHERE sw.segmentWord.segment.job.id = :jobId
+          """)
+  void deleteByJobId(@Param("jobId") Long jobId);
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -129,6 +129,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     return learningContentRepository
         .findByJobIdAndContentType(segment.getJob().getId(), LearningContentType.EXPRESSION)
         .stream()
+        .filter(expression -> expression.getTextType() == request.selectedTextType())
         .filter(expression -> overlapsSegmentTime(segment, expression))
         .filter(expression -> containsClickedWord(expression.getTitle(), clickedWord))
         .max(Comparator.comparingInt(expression -> expression.getTitle().length()));


### PR DESCRIPTION
## 작업 개요
- learning_contents에 원문/번역문 구분용 textType 저장 기능 추가

## 관련 이슈
- close #119

## 작업 내용
- Worker callback learningData payload에 textType 필드 지원 추가
- CallbackLearningContentRequest DTO 수정
- LearningContent 엔티티에 textType 필드 추가
- learning_contents.text_type 컬럼 추가
- callback 학습 데이터 저장 로직 수정
- WordExplain expression 매칭 시 selectedTextType 기준 필터링 추가
- callback 재처리 시 SavedWord FK 충돌 방지를 위한 삭제 순서 수정

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- learning_contents 기존 데이터 삭제 후 적용
- Worker callback payload에서 textType 필수 전달 필요