### PR TITLE
feat: 학습 콘텐츠 textType 반영

### DIFF
--- a/ai/api/schemas.py
+++ b/ai/api/schemas.py
@@ -187,6 +187,7 @@ class OcrItem(CamelModel):
 
 class LearningContent(CamelModel):
     content_type: LearningContentType
+    text_type: str = "ORIGINAL"
     title: str
     content: str
     start_time: float | None = None

--- a/ai/learning/service.py
+++ b/ai/learning/service.py
@@ -178,6 +178,13 @@ def _generate_with_openai(
                                                 "EXPRESSION",
                                             ],
                                         },
+                                        "textType": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ORIGINAL",
+                                                "TRANSLATION",
+                                            ],
+                                        },
                                         "title": {"type": "string"},
                                         "content": {"type": "string"},
                                         "startTime": {
@@ -189,6 +196,7 @@ def _generate_with_openai(
                                     },
                                     "required": [
                                         "contentType",
+                                        "textType",
                                         "title",
                                         "content",
                                         "startTime",
@@ -230,6 +238,7 @@ def _build_learning_instructions(
         "Use EXPRESSION for idioms, natural phrases, repeated sentence patterns, or expressions that need context. "
         "For EXPRESSION content, include literal meaning, actual meaning, natural translation, and usage context when relevant. "
         "Use KEYWORD only for a small number of repeated or theme-critical words, not every vocabulary item. "
+        "Set textType to ORIGINAL because the generated learning contents are matched against the original subtitle text. "
         "For KEYWORD and EXPRESSION, set title to the original word or phrase from the source text, "
         "and use startTime and endTime from the most relevant segment. "
         "For SUMMARY, use title 'Summary' and set startTime and endTime to null. "
@@ -249,16 +258,20 @@ def _parse_learning_data(data: dict) -> LearningData:
             continue
 
         content_type = item.get("contentType")
+        text_type = item.get("textType") or "ORIGINAL"
         title = str(item.get("title", "")).strip()
         content = str(item.get("content", "")).strip()
         if content_type not in {content_type.value for content_type in LearningContentType}:
             continue
+        if text_type not in {"ORIGINAL", "TRANSLATION"}:
+            text_type = "ORIGINAL"
         if not title or not content:
             continue
 
         contents.append(
             LearningContent(
                 content_type=LearningContentType(content_type),
+                text_type=text_type,
                 title=title,
                 content=content,
                 start_time=_optional_round_time(item.get("startTime")),
@@ -283,6 +296,7 @@ def _build_fallback_summary(subtitles: list[SubtitleSegment]) -> LearningContent
 
     return LearningContent(
         content_type=LearningContentType.SUMMARY,
+        text_type="ORIGINAL",
         title="Summary",
         content=preview_text or "Generated a learning summary from the video subtitles.",
         start_time=None,
@@ -319,6 +333,7 @@ def _build_fallback_keywords(subtitles: list[SubtitleSegment]) -> list[LearningC
         keywords.append(
             LearningContent(
                 content_type=LearningContentType.KEYWORD,
+                text_type="ORIGINAL",
                 title=original_text[word],
                 content=(
                     "Core video keyword selected from repetition and learning relevance. "
@@ -403,6 +418,7 @@ def _build_fallback_expressions(subtitles: list[SubtitleSegment]) -> list[Learni
         expressions.append(
             LearningContent(
                 content_type=LearningContentType.EXPRESSION,
+                text_type="ORIGINAL",
                 title=text[:80],
                 content=(
                     "Useful sentence-level expression for video study. "


### PR DESCRIPTION
## 작업 개요
Backend의 learning_contents.text_type 필드 추가에 맞춰 AI callback의 learningData.contents[]에 textType을 포함하도록 수정했습니다.

## 관련 이슈
- close #121 

## 작업 내용
- LearningContent schema에 textType 필드 추가
- OpenAI learning response JSON schema에 textType 필수 필드 추가
- OpenAI learning prompt에 textType=ORIGINAL 생성 규칙 반영
- fallback learning data 생성 시 SUMMARY, KEYWORD, EXPRESSION 모두 textType=ORIGINAL 포함
- OpenAI 응답에서 textType 누락 또는 비정상 값이 오는 경우 ORIGINAL로 보정

## 체크리스트 (DoD)
- [x]  빌드 및 테스트 통과 확인
- [ ]  (BE만) ./gradlew spotlessApply 실행 완료
- [ ]  관련 API 문서(Swagger 등) 업데이트 완료
- [x]  Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="1895" height="745" alt="image" src="https://github.com/user-attachments/assets/0a5925e6-243b-43f2-9abe-0bd4ced96eb3" />

## 기타 사항