### PR TITLE
fix: 프로젝트 삭제 시 learning_contents FK 충돌 수정

### DIFF
--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import com.overlang.api.dto.project.*;
 import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
@@ -40,6 +41,7 @@ public class ProjectService {
   private final SegmentWordRepository segmentWordRepository;
   private final OcrItemRepository ocrItemRepository;
   private final SavedWordRepository savedWordRepository;
+  private final LearningContentRepository learningContentRepository;
 
   public ProjectCreateResponse createProject(Long memberId, ProjectCreateRequest request) {
     Member member =
@@ -151,6 +153,7 @@ public class ProjectService {
     for (Job job : jobs) {
       Long jobId = job.getId();
 
+      learningContentRepository.deleteByJobId(jobId);
       ocrItemRepository.deleteByJobId(jobId);
       segmentWordRepository.deleteBySegmentJobId(jobId);
       segmentRepository.deleteByJobId(jobId);


### PR DESCRIPTION
## 작업 개요
- 프로젝트 삭제 시 learning_contents FK 충돌 문제 수정

## 관련 이슈
- close #125 

## 작업 내용
- Project 삭제 로직에 learning_contents 삭제 처리 추가
- Job 삭제 전 learning_contents 선삭제 처리
- 프로젝트 삭제 cascade 순서 정리
- LearningContent가 존재하는 프로젝트 삭제 테스트 진행

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- learning_contents.job_id FK로 인해 Job 삭제 실패하던 문제 수정
- 프로젝트 삭제 시 연관 learning_contents 데이터도 함께 삭제되도록 처리