### PR TITLE
refactor: JobService 1차 리팩토링

### DIFF
--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -56,10 +56,7 @@ public class JobService {
 
   @Transactional
   public JobCreateResponse createJob(Long projectId, Long memberId, JobCreateRequest request) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     validateJobCreateRequest(request);
 
@@ -146,10 +143,7 @@ public class JobService {
 
   @Transactional(readOnly = true)
   public List<JobResponse> getJobsByProject(Long projectId, Long memberId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     return jobRepository.findByProjectIdOrderByCreatedAtDesc(project.getId()).stream()
         .map(JobResponse::from)
@@ -158,25 +152,15 @@ public class JobService {
 
   @Transactional(readOnly = true)
   public JobDetailResponse getJobDetail(Long jobId, Long memberId) {
-    Job job =
-        jobRepository
-            .findByIdAndProjectMemberId(jobId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+    Job job = findJobByIdAndMemberId(jobId, memberId);
 
     return JobDetailResponse.from(job);
   }
 
   @Transactional
   public JobRetryResponse retryJob(Long projectId, Long memberId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
-
-    Job latestJob =
-        jobRepository
-            .findTopByProjectIdOrderByCreatedAtDesc(project.getId())
-            .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
+    Job latestJob = findLatestJobByProjectId(project.getId());
 
     if (latestJob.getStatus() != JobStatus.FAILED) {
       throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
@@ -383,5 +367,23 @@ public class JobService {
             .toList();
 
     learningContentRepository.saveAll(learningContents);
+  }
+
+  private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {
+    return projectRepository
+        .findByIdAndMemberId(projectId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+  }
+
+  private Job findJobByIdAndMemberId(Long jobId, Long memberId) {
+    return jobRepository
+        .findByIdAndProjectMemberId(jobId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+  }
+
+  private Job findLatestJobByProjectId(Long projectId) {
+    return jobRepository
+        .findTopByProjectIdOrderByCreatedAtDesc(projectId)
+        .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -72,10 +72,7 @@ public class JobService {
       return JobCreateResponse.from(savedJob, true);
     }
 
-    project.updateStatus(ProjectStatus.PROCESSING);
-
-    JobQueuePayload payload = createQueuePayload(project, savedJob);
-    jobQueueProducer.enqueue(payload);
+    enqueueJob(project, savedJob);
 
     return JobCreateResponse.from(savedJob, false);
   }
@@ -160,10 +157,7 @@ public class JobService {
 
     Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob));
 
-    project.updateStatus(ProjectStatus.PROCESSING);
-
-    JobQueuePayload payload = createQueuePayload(project, savedJob);
-    jobQueueProducer.enqueue(payload);
+    enqueueJob(project, savedJob);
 
     return new JobRetryResponse(
         project.getId(),
@@ -387,5 +381,12 @@ public class JobService {
         latestJob.getSourceLanguage(),
         latestJob.getTargetLanguage(),
         latestJob.getTranslationProvider());
+  }
+
+  private void enqueueJob(Project project, Job job) {
+    project.updateStatus(ProjectStatus.PROCESSING);
+
+    JobQueuePayload payload = createQueuePayload(project, job);
+    jobQueueProducer.enqueue(payload);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -254,7 +254,7 @@ public class JobService {
 
     List<Segment> savedSegments = segmentRepository.saveAll(segments);
 
-    createSegmentWords(savedSegments);
+    saveSegmentWords(savedSegments);
   }
 
   private void saveOcrItems(Job job, JobCallbackRequest request) {
@@ -289,26 +289,27 @@ public class JobService {
         blurRegion != null ? blurRegion.h() : null);
   }
 
-  private void createSegmentWords(List<Segment> segments) {
+  private void saveSegmentWords(List<Segment> segments) {
     List<SegmentWord> segmentWords =
-        segments.stream().flatMap(segment -> createSegmentWords(segment).stream()).toList();
+        segments.stream().flatMap(segment -> createWordsFromSegment(segment).stream()).toList();
 
     segmentWordRepository.saveAll(segmentWords);
   }
 
-  private List<SegmentWord> createSegmentWords(Segment segment) {
+  private List<SegmentWord> createWordsFromSegment(Segment segment) {
     List<SegmentWord> words = new ArrayList<>();
 
-    words.addAll(createSegmentWords(segment, segment.getText(), SegmentWordType.ORIGINAL));
+    words.addAll(createWordsFromText(segment, segment.getText(), SegmentWordType.ORIGINAL));
 
     words.addAll(
-        createSegmentWords(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
+        createWordsFromText(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
 
     return words;
   }
 
-  private List<SegmentWord> createSegmentWords(
+  private List<SegmentWord> createWordsFromText(
       Segment segment, String text, SegmentWordType wordType) {
+
     if (text == null || text.isBlank()) {
       return List.of();
     }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -60,15 +60,7 @@ public class JobService {
 
     validateJobCreateRequest(request);
 
-    Job job =
-        new Job(
-            project,
-            request.jobType(),
-            request.sourceLanguage(),
-            request.targetLanguage(),
-            request.translationProvider());
-
-    Job savedJob = jobRepository.save(job);
+    Job savedJob = jobRepository.save(createJobEntity(project, request));
 
     var reusableJob = resultCacheService.findReusableJob(project, request);
 
@@ -166,15 +158,7 @@ public class JobService {
       throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
     }
 
-    Job retryJob =
-        new Job(
-            project,
-            latestJob.getJobType(),
-            latestJob.getSourceLanguage(),
-            latestJob.getTargetLanguage(),
-            latestJob.getTranslationProvider());
-
-    Job savedJob = jobRepository.save(retryJob);
+    Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob));
 
     project.updateStatus(ProjectStatus.PROCESSING);
 
@@ -385,5 +369,23 @@ public class JobService {
     return jobRepository
         .findTopByProjectIdOrderByCreatedAtDesc(projectId)
         .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
+  }
+
+  private Job createJobEntity(Project project, JobCreateRequest request) {
+    return new Job(
+        project,
+        request.jobType(),
+        request.sourceLanguage(),
+        request.targetLanguage(),
+        request.translationProvider());
+  }
+
+  private Job createRetryJobEntity(Project project, Job latestJob) {
+    return new Job(
+        project,
+        latestJob.getJobType(),
+        latestJob.getSourceLanguage(),
+        latestJob.getTargetLanguage(),
+        latestJob.getTranslationProvider());
   }
 }


### PR DESCRIPTION
## 작업 개요
- JobService 구조 개선 및 중복 로직 제거를 위한 리팩토링 진행

## 관련 이슈
- #127 

## 작업 내용
- 프로젝트/작업 조회 중복 로직 메서드화
- Job 생성 로직 메서드 추출
- Job Queue 등록 로직 공통화
- SegmentWord 생성 관련 메서드 네이밍 및 구조 개선
- JobService 내부 메서드 역할 및 책임 정리
- 기능 변경 없이 코드 가독성 및 유지보수성 개선

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 기존 API 동작(createJob, retryJob, callback, job 조회) 정상 동작 확인 완료
- COMPLETED / FAILED callback 및 retry 흐름 테스트 완료