### PR TITLE
fix: OCR 중복 및 안정화

### DIFF
--- a/ai/ocr/postprocess.py
+++ b/ai/ocr/postprocess.py
@@ -13,8 +13,11 @@ LINE_HORIZONTAL_GAP_MIN = 0.06
 BLOCK_HORIZONTAL_OVERLAP_THRESHOLD = 0.35
 BLOCK_VERTICAL_GAP_RATIO = 1.6
 BLOCK_VERTICAL_GAP_MIN = 0.035
-TRACK_COVERAGE_PADDING_RATIO = 0.008
+TRACK_COVERAGE_PADDING_RATIO = 0.012
+TRACK_MULTILINE_COVERAGE_PADDING_RATIO = 0.018
 TRACK_START_DELAY_SECONDS = 0.15
+TRACK_END_TRIM_SECONDS = 0.05
+MIN_OCR_ITEM_DURATION_SECONDS = 0.25
 DUPLICATE_TEXT_SIMILARITY_THRESHOLD = 0.85
 DUPLICATE_BBOX_IOU_THRESHOLD = 0.45
 DUPLICATE_CENTER_DISTANCE_RATIO = 1.0
@@ -24,6 +27,9 @@ DUPLICATE_NORMALIZED_TEXT_THRESHOLD = 0.95
 TRACK_TEXT_STABILITY_THRESHOLD = 0.82
 TRACK_CENTER_DISTANCE_RATIO = 2.5
 TRACK_CENTER_DISTANCE_MIN = 0.08
+PROGRESSIVE_TEXT_MIN_LENGTH = 2
+PROGRESSIVE_TEXT_MIN_LENGTH_RATIO = 0.35
+PROGRESSIVE_TEXT_SCORE = 0.88
 
 
 def build_ocr_items(
@@ -98,6 +104,9 @@ def build_ocr_items(
         finalized_tracks.extend(disappeared_tracks)
 
     finalized_tracks.extend(active_tracks)
+    finalized_tracks = [
+        track for track in finalized_tracks if _should_keep_track(track)
+    ]
     finalized_tracks.sort(key=lambda track: (track["startTime"], track["endTime"]))
     return _deduplicate_ocr_items(
         [_track_to_ocr_item(track) for track in finalized_tracks]
@@ -116,6 +125,8 @@ def _create_track(
         "boundingBox": raw_item["boundingBox"],
         "boundingBoxValues": [raw_item["boundingBox"]],
         "confidenceValues": [raw_item.get("confidence")],
+        "mergedItemCountValues": [int(raw_item.get("mergedItemCount", 1))],
+        "frameIntervalSeconds": frame_interval_seconds,
         "lastTimestamp": float(raw_item["timestamp"]),
         "missingFrameCount": 0,
         "styleFramePath": raw_item.get("framePath"),
@@ -133,6 +144,7 @@ def _extend_track(
     track["missingFrameCount"] = 0
     track["confidenceValues"].append(raw_item.get("confidence"))
     track["textCandidates"].append(_build_text_candidate(raw_item))
+    track["mergedItemCountValues"].append(int(raw_item.get("mergedItemCount", 1)))
     if not raw_item.get("carriedForward"):
         track["boundingBoxValues"].append(raw_item["boundingBox"])
     track["boundingBox"] = _median_bbox(track["boundingBoxValues"])
@@ -203,28 +215,78 @@ def _track_to_ocr_item(track: dict[str, Any]) -> OcrItem:
     if confidence_values:
         confidence = round(sum(confidence_values) / len(confidence_values), 4)
 
+    coverage_box = _track_coverage_bbox(track)
     return OcrItem(
         start_time=_resolve_track_start_time(track),
-        end_time=round(float(track["endTime"]), 3),
+        end_time=_resolve_track_end_time(track),
         origin_text=_resolve_track_text(track),
         translated_text=None,
-        bounding_box=_coverage_bbox(track["boundingBoxValues"]),
+        bounding_box=coverage_box,
         confidence=confidence,
         style=build_ocr_style(
             track.get("styleFramePath"),
-            _coverage_bbox(track["boundingBoxValues"]),
+            coverage_box,
         ),
+    )
+
+
+def _should_keep_track(track: dict[str, Any]) -> bool:
+    duration = float(track["endTime"]) - float(track["startTime"])
+    real_detection_count = len(track.get("boundingBoxValues", []))
+    max_confidence = max(
+        (
+            float(confidence)
+            for confidence in track.get("confidenceValues", [])
+            if confidence is not None
+        ),
+        default=0.0,
+    )
+    return (
+        duration >= MIN_OCR_ITEM_DURATION_SECONDS
+        or real_detection_count >= 2
+        or max_confidence >= 0.75
     )
 
 
 def _resolve_track_start_time(track: dict[str, Any]) -> float:
     start_time = float(track["startTime"])
     end_time = float(track["endTime"])
-    delayed_start_time = start_time + TRACK_START_DELAY_SECONDS
+    if _has_progressive_text_candidates(track):
+        representative_timestamp = _resolve_track_text_group(track).get(
+            "firstTimestamp",
+        )
+        if representative_timestamp is not None:
+            start_time = max(start_time, float(representative_timestamp))
+
+    duration = max(0.0, end_time - start_time)
+    start_delay = min(TRACK_START_DELAY_SECONDS, duration * 0.25)
+    delayed_start_time = start_time + start_delay
     if delayed_start_time >= end_time:
         return round(start_time, 3)
 
     return round(delayed_start_time, 3)
+
+
+def _resolve_track_end_time(track: dict[str, Any]) -> float:
+    start_time = _resolve_track_start_time(track)
+    end_time = float(track["endTime"])
+    frame_interval_seconds = float(track.get("frameIntervalSeconds") or 0.0)
+    end_trim_seconds = min(TRACK_END_TRIM_SECONDS, frame_interval_seconds * 0.25)
+    trimmed_end_time = end_time - end_trim_seconds
+    if trimmed_end_time <= start_time:
+        return round(end_time, 3)
+
+    return round(trimmed_end_time, 3)
+
+
+def _track_coverage_bbox(track: dict[str, Any]) -> BoundingBox:
+    merged_item_count = max(track.get("mergedItemCountValues", [1]), default=1)
+    resolved_text = _resolve_track_text(track)
+    padding_ratio = TRACK_COVERAGE_PADDING_RATIO
+    if "\n" in resolved_text or merged_item_count > 1:
+        padding_ratio = TRACK_MULTILINE_COVERAGE_PADDING_RATIO
+
+    return _coverage_bbox(track["boundingBoxValues"], padding_ratio=padding_ratio)
 
 
 def _merge_adjacent_frame_items(
@@ -278,64 +340,14 @@ def _is_duplicate_frame_item(
         left_item["originText"],
         right_item["originText"],
     )
-
-
-def _build_text_candidate(raw_item: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "text": str(raw_item.get("originText", "")).strip(),
-        "confidence": float(raw_item.get("confidence") or 0.0),
-        "timestamp": float(raw_item.get("timestamp", 0.0)),
-    }
-
-
-def _resolve_track_text(track: dict[str, Any]) -> str:
-    candidates = [
-        candidate
-        for candidate in track.get("textCandidates", [])
-        if str(candidate.get("text", "")).strip()
-    ]
-    if not candidates:
-        return str(track.get("originText", "")).strip()
-
-    grouped_candidates: dict[str, dict[str, Any]] = {}
-    for candidate in candidates:
-        text = str(candidate["text"]).strip()
-        normalized_text = _normalize_text(text)
-        if not normalized_text:
-            continue
-
-        group = grouped_candidates.setdefault(
-            normalized_text,
-            {
-                "text": text,
-                "count": 0,
-                "confidence": 0.0,
-                "lastTimestamp": 0.0,
-            },
-        )
-        group["count"] += 1
-        group["confidence"] += float(candidate.get("confidence") or 0.0)
-        group["lastTimestamp"] = max(
-            float(group["lastTimestamp"]),
-            float(candidate.get("timestamp") or 0.0),
-        )
-        if len(text) > len(str(group["text"])):
-            group["text"] = text
-
-    if not grouped_candidates:
-        return str(track.get("originText", "")).strip()
-
-    best_group = max(
-        grouped_candidates.values(),
-        key=lambda group: (
-            int(group["count"]),
-            float(group["confidence"]),
-            float(group["lastTimestamp"]),
-            len(str(group["text"])),
-        ),
+    is_progressive_text = _is_progressive_text_pair(
+        left_item["originText"],
+        right_item["originText"],
     )
-    return str(best_group["text"]).strip()
-    if text_similarity < DUPLICATE_TEXT_SIMILARITY_THRESHOLD:
+    if (
+        text_similarity < DUPLICATE_TEXT_SIMILARITY_THRESHOLD
+        and not is_progressive_text
+    ):
         return False
 
     left_box = left_item["boundingBox"]
@@ -350,6 +362,125 @@ def _resolve_track_text(track: dict[str, Any]) -> str:
         return True
 
     return _is_near_bbox_center(left_box, right_box)
+
+
+def _build_text_candidate(raw_item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "text": str(raw_item.get("originText", "")).strip(),
+        "confidence": float(raw_item.get("confidence") or 0.0),
+        "timestamp": float(raw_item.get("timestamp", 0.0)),
+    }
+
+
+def _resolve_track_text(track: dict[str, Any]) -> str:
+    return str(_resolve_track_text_group(track).get("text", "")).strip()
+
+
+def _resolve_track_text_group(track: dict[str, Any]) -> dict[str, Any]:
+    candidates = [
+        candidate
+        for candidate in track.get("textCandidates", [])
+        if str(candidate.get("text", "")).strip()
+    ]
+    if not candidates:
+        return {
+            "text": str(track.get("originText", "")).strip(),
+            "count": 0,
+            "confidence": 0.0,
+            "firstTimestamp": float(track.get("startTime", 0.0)),
+            "lastTimestamp": float(track.get("startTime", 0.0)),
+        }
+
+    grouped_candidates: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        text = str(candidate["text"]).strip()
+        normalized_text = _normalize_text(text)
+        if not normalized_text:
+            continue
+
+        timestamp = float(candidate.get("timestamp") or 0.0)
+        group = grouped_candidates.setdefault(
+            normalized_text,
+            {
+                "text": text,
+                "count": 0,
+                "confidence": 0.0,
+                "firstTimestamp": timestamp,
+                "lastTimestamp": timestamp,
+            },
+        )
+        group["count"] += 1
+        group["confidence"] += float(candidate.get("confidence") or 0.0)
+        group["firstTimestamp"] = min(float(group["firstTimestamp"]), timestamp)
+        group["lastTimestamp"] = max(float(group["lastTimestamp"]), timestamp)
+        if len(text) > len(str(group["text"])):
+            group["text"] = text
+
+    if not grouped_candidates:
+        return {
+            "text": str(track.get("originText", "")).strip(),
+            "count": 0,
+            "confidence": 0.0,
+            "firstTimestamp": float(track.get("startTime", 0.0)),
+            "lastTimestamp": float(track.get("startTime", 0.0)),
+        }
+
+    groups = list(grouped_candidates.values())
+    if _has_progressive_text_candidates(track):
+        return max(
+            groups,
+            key=lambda group: (
+                len(_compact_text(str(group["text"]))),
+                int(group["count"]),
+                float(group["confidence"]),
+                float(group["lastTimestamp"]),
+            ),
+        )
+
+    return max(
+        groups,
+        key=lambda group: (
+            int(group["count"]),
+            float(group["confidence"]),
+            float(group["lastTimestamp"]),
+            len(str(group["text"])),
+        ),
+    )
+
+
+def _has_progressive_text_candidates(track: dict[str, Any]) -> bool:
+    candidates = [
+        str(candidate.get("text", "")).strip()
+        for candidate in track.get("textCandidates", [])
+        if str(candidate.get("text", "")).strip()
+    ]
+    for left_index, left_text in enumerate(candidates):
+        for right_text in candidates[left_index + 1 :]:
+            if _is_progressive_text_pair(left_text, right_text):
+                return True
+
+    return False
+
+
+def _is_progressive_text_pair(left: str, right: str) -> bool:
+    left_compact = _compact_text(left)
+    right_compact = _compact_text(right)
+    if not left_compact or not right_compact:
+        return False
+
+    shorter_length = min(len(left_compact), len(right_compact))
+    longer_length = max(len(left_compact), len(right_compact))
+    if shorter_length < PROGRESSIVE_TEXT_MIN_LENGTH:
+        return False
+
+    if shorter_length / longer_length < PROGRESSIVE_TEXT_MIN_LENGTH_RATIO:
+        return False
+
+    return left_compact in right_compact or right_compact in left_compact
+
+
+def _compact_text(text: str) -> str:
+    return "".join(_normalize_text(text).split())
 
 
 def _merge_items_into_lines(
@@ -552,7 +683,8 @@ def _is_duplicate_merge_item(
         return False
 
     text_similarity = 1.0 if left_text == right_text else _similarity(left_text, right_text)
-    if text_similarity < DUPLICATE_NORMALIZED_TEXT_THRESHOLD:
+    is_progressive_text = _is_progressive_text_pair(left_text, right_text)
+    if text_similarity < DUPLICATE_NORMALIZED_TEXT_THRESHOLD and not is_progressive_text:
         return False
 
     left_box = left_item["boundingBox"]
@@ -599,7 +731,12 @@ def _is_duplicate_ocr_item(
     left_item: OcrItem,
     right_item: OcrItem,
 ) -> bool:
-    if _text_similarity(left_item.origin_text, right_item.origin_text) < 0.9:
+    text_similarity = _text_similarity(left_item.origin_text, right_item.origin_text)
+    is_progressive_text = _is_progressive_text_pair(
+        left_item.origin_text,
+        right_item.origin_text,
+    )
+    if text_similarity < 0.9 and not is_progressive_text:
         return False
 
     if _time_overlap_ratio(left_item, right_item) < 0.5:
@@ -698,30 +835,53 @@ def _find_best_matching_active_track(
         if id(track) in matched_track_ids:
             continue
 
+        track_text = _resolve_track_text(track) or str(track.get("originText", ""))
+        raw_text = str(raw_item.get("originText", ""))
         text_similarity = _text_similarity(
-            track["originText"],
-            raw_item["originText"],
+            track_text,
+            raw_text,
         )
-        if text_similarity < min(text_similarity_threshold, TRACK_TEXT_STABILITY_THRESHOLD):
+        is_progressive_text = _is_progressive_track_match(track, raw_text)
+        if (
+            text_similarity < min(text_similarity_threshold, TRACK_TEXT_STABILITY_THRESHOLD)
+            and not is_progressive_text
+        ):
             continue
 
         bbox_overlap = _bbox_iou(track["boundingBox"], raw_item["boundingBox"])
+        is_stable_scaling = _is_stable_scaling_match(
+            track["boundingBox"],
+            raw_item["boundingBox"],
+        )
         if bbox_overlap <= 0 and not _is_similar_bbox(
             track["boundingBox"],
             raw_item["boundingBox"],
             bbox_tolerance,
-        ) and not _is_stable_scaling_match(
-            track["boundingBox"],
-            raw_item["boundingBox"],
-        ):
+        ) and not is_stable_scaling:
             continue
 
-        candidates.append((text_similarity + bbox_overlap, track))
+        text_score = max(
+            text_similarity,
+            PROGRESSIVE_TEXT_SCORE if is_progressive_text else 0.0,
+        )
+        scaling_score = 0.1 if is_stable_scaling else 0.0
+        candidates.append((text_score + bbox_overlap + scaling_score, track))
 
     if not candidates:
         return None
 
     return max(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _is_progressive_track_match(track: dict[str, Any], raw_text: str) -> bool:
+    track_text = _resolve_track_text(track) or str(track.get("originText", ""))
+    if _is_progressive_text_pair(track_text, raw_text):
+        return True
+
+    return any(
+        _is_progressive_text_pair(str(candidate.get("text", "")), raw_text)
+        for candidate in track.get("textCandidates", [])
+    )
 
 
 def _is_stable_scaling_match(

--- a/ai/ocr/postprocess.py
+++ b/ai/ocr/postprocess.py
@@ -18,6 +18,12 @@ TRACK_START_DELAY_SECONDS = 0.15
 DUPLICATE_TEXT_SIMILARITY_THRESHOLD = 0.85
 DUPLICATE_BBOX_IOU_THRESHOLD = 0.45
 DUPLICATE_CENTER_DISTANCE_RATIO = 1.0
+DUPLICATE_CONTAINMENT_RATIO = 0.8
+DUPLICATE_COVERAGE_RATIO = 0.9
+DUPLICATE_NORMALIZED_TEXT_THRESHOLD = 0.95
+TRACK_TEXT_STABILITY_THRESHOLD = 0.82
+TRACK_CENTER_DISTANCE_RATIO = 2.5
+TRACK_CENTER_DISTANCE_MIN = 0.08
 
 
 def build_ocr_items(
@@ -93,7 +99,9 @@ def build_ocr_items(
 
     finalized_tracks.extend(active_tracks)
     finalized_tracks.sort(key=lambda track: (track["startTime"], track["endTime"]))
-    return [_track_to_ocr_item(track) for track in finalized_tracks]
+    return _deduplicate_ocr_items(
+        [_track_to_ocr_item(track) for track in finalized_tracks]
+    )
 
 
 def _create_track(
@@ -104,6 +112,7 @@ def _create_track(
         "startTime": float(raw_item["timestamp"]),
         "endTime": round(float(raw_item["timestamp"]) + frame_interval_seconds, 3),
         "originText": raw_item["originText"],
+        "textCandidates": [_build_text_candidate(raw_item)],
         "boundingBox": raw_item["boundingBox"],
         "boundingBoxValues": [raw_item["boundingBox"]],
         "confidenceValues": [raw_item.get("confidence")],
@@ -123,6 +132,7 @@ def _extend_track(
     track["lastTimestamp"] = float(raw_item["timestamp"])
     track["missingFrameCount"] = 0
     track["confidenceValues"].append(raw_item.get("confidence"))
+    track["textCandidates"].append(_build_text_candidate(raw_item))
     if not raw_item.get("carriedForward"):
         track["boundingBoxValues"].append(raw_item["boundingBox"])
     track["boundingBox"] = _median_bbox(track["boundingBoxValues"])
@@ -196,7 +206,7 @@ def _track_to_ocr_item(track: dict[str, Any]) -> OcrItem:
     return OcrItem(
         start_time=_resolve_track_start_time(track),
         end_time=round(float(track["endTime"]), 3),
-        origin_text=track["originText"],
+        origin_text=_resolve_track_text(track),
         translated_text=None,
         bounding_box=_coverage_bbox(track["boundingBoxValues"]),
         confidence=confidence,
@@ -264,15 +274,79 @@ def _is_duplicate_frame_item(
     left_item: dict[str, Any],
     right_item: dict[str, Any],
 ) -> bool:
-    if (
-        _text_similarity(left_item["originText"], right_item["originText"])
-        < DUPLICATE_TEXT_SIMILARITY_THRESHOLD
-    ):
+    text_similarity = _text_similarity(
+        left_item["originText"],
+        right_item["originText"],
+    )
+
+
+def _build_text_candidate(raw_item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "text": str(raw_item.get("originText", "")).strip(),
+        "confidence": float(raw_item.get("confidence") or 0.0),
+        "timestamp": float(raw_item.get("timestamp", 0.0)),
+    }
+
+
+def _resolve_track_text(track: dict[str, Any]) -> str:
+    candidates = [
+        candidate
+        for candidate in track.get("textCandidates", [])
+        if str(candidate.get("text", "")).strip()
+    ]
+    if not candidates:
+        return str(track.get("originText", "")).strip()
+
+    grouped_candidates: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        text = str(candidate["text"]).strip()
+        normalized_text = _normalize_text(text)
+        if not normalized_text:
+            continue
+
+        group = grouped_candidates.setdefault(
+            normalized_text,
+            {
+                "text": text,
+                "count": 0,
+                "confidence": 0.0,
+                "lastTimestamp": 0.0,
+            },
+        )
+        group["count"] += 1
+        group["confidence"] += float(candidate.get("confidence") or 0.0)
+        group["lastTimestamp"] = max(
+            float(group["lastTimestamp"]),
+            float(candidate.get("timestamp") or 0.0),
+        )
+        if len(text) > len(str(group["text"])):
+            group["text"] = text
+
+    if not grouped_candidates:
+        return str(track.get("originText", "")).strip()
+
+    best_group = max(
+        grouped_candidates.values(),
+        key=lambda group: (
+            int(group["count"]),
+            float(group["confidence"]),
+            float(group["lastTimestamp"]),
+            len(str(group["text"])),
+        ),
+    )
+    return str(best_group["text"]).strip()
+    if text_similarity < DUPLICATE_TEXT_SIMILARITY_THRESHOLD:
         return False
 
     left_box = left_item["boundingBox"]
     right_box = right_item["boundingBox"]
     if _bbox_iou(left_box, right_box) >= DUPLICATE_BBOX_IOU_THRESHOLD:
+        return True
+
+    if _bbox_containment_ratio(left_box, right_box) >= DUPLICATE_CONTAINMENT_RATIO:
+        return True
+
+    if _bbox_coverage_ratio(left_box, right_box) >= DUPLICATE_COVERAGE_RATIO:
         return True
 
     return _is_near_bbox_center(left_box, right_box)
@@ -429,26 +503,116 @@ def _merge_raw_items(
     separator: str = " ",
 ) -> dict[str, Any]:
     merged_item = dict(raw_items[0])
+    merge_items = _deduplicate_merge_items(raw_items)
     merged_item["originText"] = separator.join(
         str(item["originText"]).strip()
-        for item in raw_items
+        for item in merge_items
         if str(item.get("originText", "")).strip()
     )
     merged_item["boundingBox"] = _union_bbox(
-        [item["boundingBox"] for item in raw_items]
+        [item["boundingBox"] for item in merge_items]
     )
     confidences = [
         float(item["confidence"])
-        for item in raw_items
+        for item in merge_items
         if item.get("confidence") is not None
     ]
     merged_item["confidence"] = (
         round(sum(confidences) / len(confidences), 4) if confidences else None
     )
     merged_item["mergedItemCount"] = sum(
-        int(item.get("mergedItemCount", 1)) for item in raw_items
+        int(item.get("mergedItemCount", 1)) for item in merge_items
     )
     return merged_item
+
+
+def _deduplicate_merge_items(
+    raw_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    deduplicated_items: list[dict[str, Any]] = []
+    for raw_item in raw_items:
+        if any(
+            _is_duplicate_merge_item(raw_item, kept_item)
+            for kept_item in deduplicated_items
+        ):
+            continue
+
+        deduplicated_items.append(raw_item)
+
+    return deduplicated_items
+
+
+def _is_duplicate_merge_item(
+    left_item: dict[str, Any],
+    right_item: dict[str, Any],
+) -> bool:
+    left_text = _normalize_text(left_item.get("originText", ""))
+    right_text = _normalize_text(right_item.get("originText", ""))
+    if not left_text or not right_text:
+        return False
+
+    text_similarity = 1.0 if left_text == right_text else _similarity(left_text, right_text)
+    if text_similarity < DUPLICATE_NORMALIZED_TEXT_THRESHOLD:
+        return False
+
+    left_box = left_item["boundingBox"]
+    right_box = right_item["boundingBox"]
+    return (
+        _bbox_iou(left_box, right_box) >= DUPLICATE_BBOX_IOU_THRESHOLD
+        or _bbox_containment_ratio(left_box, right_box) >= DUPLICATE_CONTAINMENT_RATIO
+        or _bbox_coverage_ratio(left_box, right_box) >= DUPLICATE_COVERAGE_RATIO
+        or _is_near_bbox_center(left_box, right_box)
+    )
+
+
+def _deduplicate_ocr_items(
+    ocr_items: list[OcrItem],
+) -> list[OcrItem]:
+    if len(ocr_items) <= 1:
+        return ocr_items
+
+    sorted_items = sorted(
+        ocr_items,
+        key=lambda item: (
+            float(item.confidence or 0.0),
+            item.end_time - item.start_time,
+        ),
+        reverse=True,
+    )
+    deduplicated_items: list[OcrItem] = []
+    for ocr_item in sorted_items:
+        if any(
+            _is_duplicate_ocr_item(ocr_item, kept_item)
+            for kept_item in deduplicated_items
+        ):
+            continue
+
+        deduplicated_items.append(ocr_item)
+
+    return sorted(
+        deduplicated_items,
+        key=lambda item: (item.start_time, item.end_time, item.bounding_box.y),
+    )
+
+
+def _is_duplicate_ocr_item(
+    left_item: OcrItem,
+    right_item: OcrItem,
+) -> bool:
+    if _text_similarity(left_item.origin_text, right_item.origin_text) < 0.9:
+        return False
+
+    if _time_overlap_ratio(left_item, right_item) < 0.5:
+        return False
+
+    left_box = left_item.bounding_box
+    right_box = right_item.bounding_box
+    return (
+        _bbox_iou(left_box, right_box) >= DUPLICATE_BBOX_IOU_THRESHOLD
+        or _bbox_containment_ratio(left_box, right_box) >= DUPLICATE_CONTAINMENT_RATIO
+        or _bbox_coverage_ratio(left_box, right_box) >= DUPLICATE_COVERAGE_RATIO
+        or _is_near_bbox_center(left_box, right_box)
+    )
 
 
 def _group_raw_items_by_timestamp(
@@ -538,7 +702,7 @@ def _find_best_matching_active_track(
             track["originText"],
             raw_item["originText"],
         )
-        if text_similarity < text_similarity_threshold:
+        if text_similarity < min(text_similarity_threshold, TRACK_TEXT_STABILITY_THRESHOLD):
             continue
 
         bbox_overlap = _bbox_iou(track["boundingBox"], raw_item["boundingBox"])
@@ -546,6 +710,9 @@ def _find_best_matching_active_track(
             track["boundingBox"],
             raw_item["boundingBox"],
             bbox_tolerance,
+        ) and not _is_stable_scaling_match(
+            track["boundingBox"],
+            raw_item["boundingBox"],
         ):
             continue
 
@@ -555,6 +722,36 @@ def _find_best_matching_active_track(
         return None
 
     return max(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _is_stable_scaling_match(
+    left: BoundingBox,
+    right: BoundingBox,
+) -> bool:
+    center_x_distance = abs(_bbox_center_x(left) - _bbox_center_x(right))
+    center_y_distance = abs(_bbox_center_y(left) - _bbox_center_y(right))
+    max_height = max(left.h, right.h)
+    max_width = max(left.w, right.w)
+    max_center_x_distance = max(
+        TRACK_CENTER_DISTANCE_MIN,
+        max_width * TRACK_CENTER_DISTANCE_RATIO,
+    )
+    max_center_y_distance = max(
+        TRACK_CENTER_DISTANCE_MIN,
+        max_height * TRACK_CENTER_DISTANCE_RATIO,
+    )
+    if (
+        center_x_distance > max_center_x_distance
+        or center_y_distance > max_center_y_distance
+    ):
+        return False
+
+    return (
+        _bbox_containment_ratio(left, right) >= 0.35
+        or _bbox_coverage_ratio(left, right) >= 0.35
+        or _horizontal_overlap_ratio(left, right) >= 0.35
+        or _vertical_overlap_ratio(left, right) >= 0.35
+    )
 
 
 def _is_same_text(
@@ -628,6 +825,65 @@ def _bbox_iou(
         return 0.0
 
     return intersection_area / union_area
+
+
+def _time_overlap_ratio(
+    left: OcrItem,
+    right: OcrItem,
+) -> float:
+    overlap = max(
+        0.0,
+        min(left.end_time, right.end_time) - max(left.start_time, right.start_time),
+    )
+    shorter_duration = min(
+        left.end_time - left.start_time,
+        right.end_time - right.start_time,
+    )
+    if shorter_duration <= 0:
+        return 0.0
+
+    return overlap / shorter_duration
+
+
+def _bbox_intersection_area(
+    left: BoundingBox,
+    right: BoundingBox,
+) -> float:
+    intersection_w = max(
+        0.0,
+        min(left.x + left.w, right.x + right.w) - max(left.x, right.x),
+    )
+    intersection_h = max(
+        0.0,
+        min(left.y + left.h, right.y + right.h) - max(left.y, right.y),
+    )
+    return intersection_w * intersection_h
+
+
+def _bbox_containment_ratio(
+    left: BoundingBox,
+    right: BoundingBox,
+) -> float:
+    left_area = left.w * left.h
+    right_area = right.w * right.h
+    smaller_area = min(left_area, right_area)
+    if smaller_area <= 0:
+        return 0.0
+
+    return _bbox_intersection_area(left, right) / smaller_area
+
+
+def _bbox_coverage_ratio(
+    left: BoundingBox,
+    right: BoundingBox,
+) -> float:
+    left_area = left.w * left.h
+    right_area = right.w * right.h
+    larger_area = max(left_area, right_area)
+    if larger_area <= 0:
+        return 0.0
+
+    return _bbox_intersection_area(left, right) / larger_area
 
 
 def _bbox_center_y(bounding_box: BoundingBox) -> float:


### PR DESCRIPTION
## 작업 개요
OCR 결과에서 동일 텍스트가 중복 생성되거나, 텍스트 확대/축소 과정에서 같은 글자가 다른 OCR item으로 분리되는 문제를 개선했습니다.
글자가 타이핑되듯 점진적으로 나타나는 경우 OCR 번역 overlay가 깜빡이는 문제를 개선했습니다.

## 관련 이슈
- close #129 
- close #131 

## 작업 내용
- 같은 프레임 내 OCR 중복 제거 기준 강화
- bbox IoU 외 bbox 포함 관계 및 coverage 기준 추가
- line/block merge 단계에서 동일 텍스트 반복 결합 방지
- 최종 ocrItems 생성 이후 시간대/위치/텍스트 기준 중복 제거
- bbox 확대/축소 중에도 같은 텍스트는 같은 track으로 유지
- track 내부 대표 텍스트를 confidence, 등장 횟수, 최신성 기준으로 안정화
- `He → Hell → Hello`처럼 점진적으로 길어지는 텍스트를 하나의 OCR track으로 병합
- progressive text는 최종 텍스트를 representative text로 선택
- progressive text의 표시 시작 시점을 최종 텍스트 인식 시점 기준으로 보정
- 서로 다른 위치에 있는 동일 텍스트는 유지되도록 처리

## 체크리스트 (DoD)
- [x]  빌드 및 테스트 통과 확인
- [ ]  (BE만) ./gradlew spotlessApply 실행 완료
- [ ]  관련 API 문서(Swagger 등) 업데이트 완료
- [x]  Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항