### PR TITLE
refactor: JobService 책임 분리 및 구조 개선

### DIFF
--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayloadFactory.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayloadFactory.java
@@ -1,0 +1,52 @@
+package com.overlang.domain.job.queue;
+
+import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.entity.SourceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JobQueuePayloadFactory {
+
+  private final S3UploadService s3UploadService;
+
+  public JobQueuePayload create(Project project, Job job) {
+    SourceType sourceType = project.getSourceType();
+
+    return switch (sourceType) {
+      case UPLOAD -> {
+        String presignedUrl = s3UploadService.generatePresignedGetUrl(project.getFileKey());
+
+        yield new JobQueuePayload(
+            job.getId(),
+            project.getId(),
+            project.getMember().getId(),
+            sourceType,
+            null,
+            project.getFileKey(),
+            presignedUrl,
+            job.getJobType(),
+            job.getSourceLanguage(),
+            job.getTargetLanguage(),
+            job.getTranslationProvider());
+      }
+
+      case YOUTUBE ->
+          new JobQueuePayload(
+              job.getId(),
+              project.getId(),
+              project.getMember().getId(),
+              sourceType,
+              project.getSourceUrl(),
+              null,
+              null,
+              job.getJobType(),
+              job.getSourceLanguage(),
+              job.getTargetLanguage(),
+              job.getTranslationProvider());
+    };
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -4,7 +4,9 @@ import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
@@ -25,6 +27,8 @@ public class JobResultService {
   private final SegmentWordRepository segmentWordRepository;
   private final OcrItemRepository ocrItemRepository;
   private final JobRepository jobRepository;
+  private final LearningContentRepository learningContentRepository;
+  private final SavedWordRepository savedWordRepository;
 
   @Transactional(readOnly = true)
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
@@ -82,5 +86,13 @@ public class JobResultService {
     if (!jobRepository.existsByIdAndProjectMemberId(jobId, memberId)) {
       throw new IllegalArgumentException("작업을 찾을 수 없습니다.");
     }
+  }
+
+  public void deletePreviousResults(Long jobId) {
+    savedWordRepository.deleteByJobId(jobId);
+    segmentWordRepository.deleteBySegmentJobId(jobId);
+    segmentRepository.deleteByJobId(jobId);
+    ocrItemRepository.deleteByJobId(jobId);
+    learningContentRepository.deleteByJobId(jobId);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,8 +1,10 @@
 package com.overlang.domain.job.service;
 
+import com.overlang.api.dto.job.JobCallbackRequest;
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
+import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
@@ -12,6 +14,7 @@ import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -94,5 +97,66 @@ public class JobResultService {
     segmentRepository.deleteByJobId(jobId);
     ocrItemRepository.deleteByJobId(jobId);
     learningContentRepository.deleteByJobId(jobId);
+  }
+
+  private static final String WORD_SPLIT_REGEX = "\\s+";
+
+  public void saveSegments(Job job, JobCallbackRequest request) {
+    if (request.segments() == null) return;
+
+    List<Segment> segments =
+        request.segments().stream()
+            .map(
+                s ->
+                    new Segment(
+                        job,
+                        s.startTime(),
+                        s.endTime(),
+                        s.seq(),
+                        s.text(),
+                        s.translatedText(),
+                        s.languageCode()))
+            .toList();
+
+    List<Segment> savedSegments = segmentRepository.saveAll(segments);
+
+    saveSegmentWords(savedSegments);
+  }
+
+  private void saveSegmentWords(List<Segment> segments) {
+    List<SegmentWord> segmentWords =
+        segments.stream().flatMap(segment -> createWordsFromSegment(segment).stream()).toList();
+
+    segmentWordRepository.saveAll(segmentWords);
+  }
+
+  private List<SegmentWord> createWordsFromSegment(Segment segment) {
+    List<SegmentWord> words = new ArrayList<>();
+
+    words.addAll(createWordsFromText(segment, segment.getText(), SegmentWordType.ORIGINAL));
+
+    words.addAll(
+        createWordsFromText(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
+
+    return words;
+  }
+
+  private List<SegmentWord> createWordsFromText(
+      Segment segment, String text, SegmentWordType wordType) {
+
+    if (text == null || text.isBlank()) {
+      return List.of();
+    }
+
+    String[] words = text.split(WORD_SPLIT_REGEX);
+    List<SegmentWord> segmentWords = new ArrayList<>();
+
+    for (int i = 0; i < words.length; i++) {
+      segmentWords.add(
+          new SegmentWord(
+              segment, i + 1, segment.getStartTime(), segment.getEndTime(), words[i], wordType));
+    }
+
+    return segmentWords;
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,5 +1,6 @@
 package com.overlang.domain.job.service;
 
+import com.overlang.api.dto.job.CallbackLearningDataRequest;
 import com.overlang.api.dto.job.CallbackOcrItemRequest;
 import com.overlang.api.dto.job.JobCallbackRequest;
 import com.overlang.api.dto.ocr.BlurRegionRequest;
@@ -9,6 +10,7 @@ import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.entity.OcrItem;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
@@ -194,5 +196,27 @@ public class JobResultService {
         blurRegion != null ? blurRegion.y() : null,
         blurRegion != null ? blurRegion.w() : null,
         blurRegion != null ? blurRegion.h() : null);
+  }
+
+  public void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {
+    if (learningData == null || learningData.contents() == null) {
+      return;
+    }
+
+    List<LearningContent> learningContents =
+        learningData.contents().stream()
+            .map(
+                content ->
+                    new LearningContent(
+                        job,
+                        content.contentType(),
+                        content.textType(),
+                        content.title(),
+                        content.content(),
+                        content.startTime(),
+                        content.endTime()))
+            .toList();
+
+    learningContentRepository.saveAll(learningContents);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,12 +1,16 @@
 package com.overlang.domain.job.service;
 
+import com.overlang.api.dto.job.CallbackOcrItemRequest;
 import com.overlang.api.dto.job.JobCallbackRequest;
+import com.overlang.api.dto.ocr.BlurRegionRequest;
 import com.overlang.api.dto.ocr.OcrItemResponse;
+import com.overlang.api.dto.ocr.OcrStyleRequest;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.repository.LearningContentRepository;
+import com.overlang.domain.ocr.entity.OcrItem;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.Segment;
@@ -158,5 +162,37 @@ public class JobResultService {
     }
 
     return segmentWords;
+  }
+
+  public void saveOcrItems(Job job, JobCallbackRequest request) {
+    if (request.ocrItems() == null) return;
+
+    List<OcrItem> ocrItems = request.ocrItems().stream().map(o -> toOcrItem(job, o)).toList();
+
+    ocrItemRepository.saveAll(ocrItems);
+  }
+
+  private OcrItem toOcrItem(Job job, CallbackOcrItemRequest o) {
+    OcrStyleRequest style = o.style();
+    BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
+
+    return new OcrItem(
+        job,
+        o.startTime(),
+        o.endTime(),
+        o.originText(),
+        o.translatedText(),
+        o.boundingBox().x(),
+        o.boundingBox().y(),
+        o.boundingBox().w(),
+        o.boundingBox().h(),
+        o.confidence(),
+        style != null ? style.backgroundColor() : null,
+        style != null ? style.dominantBackgroundColor() : null,
+        style != null ? style.textColor() : null,
+        blurRegion != null ? blurRegion.x() : null,
+        blurRegion != null ? blurRegion.y() : null,
+        blurRegion != null ? blurRegion.w() : null,
+        blurRegion != null ? blurRegion.h() : null);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -1,8 +1,6 @@
 package com.overlang.domain.job.service;
 
 import com.overlang.api.dto.job.*;
-import com.overlang.api.dto.ocr.BlurRegionRequest;
-import com.overlang.api.dto.ocr.OcrStyleRequest;
 import com.overlang.domain.cache.service.ResultCacheService;
 import com.overlang.domain.cache.service.ResultCopyService;
 import com.overlang.domain.file.service.S3UploadService;
@@ -14,15 +12,10 @@ import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.repository.LearningContentRepository;
-import com.overlang.domain.ocr.entity.OcrItem;
-import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
-import com.overlang.domain.savedword.repository.SavedWordRepository;
-import com.overlang.domain.segment.repository.SegmentRepository;
-import com.overlang.domain.segment.repository.SegmentWordRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,13 +32,9 @@ public class JobService {
   private final JobRepository jobRepository;
   private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
-  private final SegmentRepository segmentRepository;
-  private final SegmentWordRepository segmentWordRepository;
-  private final OcrItemRepository ocrItemRepository;
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
   private final LearningContentRepository learningContentRepository;
-  private final SavedWordRepository savedWordRepository;
   private final JobResultService jobResultService;
 
   @Value("${worker.secret}")
@@ -211,7 +200,7 @@ public class JobService {
 
     jobResultService.deletePreviousResults(job.getId());
     jobResultService.saveSegments(job, request);
-    saveOcrItems(job, request);
+    jobResultService.saveOcrItems(job, request);
     saveLearningContents(job, request.learningData());
 
     job.getProject().markCompleted();
@@ -222,38 +211,6 @@ public class JobService {
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
     job.getProject().markFailed();
-  }
-
-  private void saveOcrItems(Job job, JobCallbackRequest request) {
-    if (request.ocrItems() == null) return;
-
-    List<OcrItem> ocrItems = request.ocrItems().stream().map(o -> toOcrItem(job, o)).toList();
-
-    ocrItemRepository.saveAll(ocrItems);
-  }
-
-  private OcrItem toOcrItem(Job job, CallbackOcrItemRequest o) {
-    OcrStyleRequest style = o.style();
-    BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
-
-    return new OcrItem(
-        job,
-        o.startTime(),
-        o.endTime(),
-        o.originText(),
-        o.translatedText(),
-        o.boundingBox().x(),
-        o.boundingBox().y(),
-        o.boundingBox().w(),
-        o.boundingBox().h(),
-        o.confidence(),
-        style != null ? style.backgroundColor() : null,
-        style != null ? style.dominantBackgroundColor() : null,
-        style != null ? style.textColor() : null,
-        blurRegion != null ? blurRegion.x() : null,
-        blurRegion != null ? blurRegion.y() : null,
-        blurRegion != null ? blurRegion.w() : null,
-        blurRegion != null ? blurRegion.h() : null);
   }
 
   private void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -8,11 +8,11 @@ import com.overlang.domain.job.entity.CurrentStage;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.entity.JobStatus;
 import com.overlang.domain.job.queue.JobQueuePayload;
+import com.overlang.domain.job.queue.JobQueuePayloadFactory;
 import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
-import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +31,7 @@ public class JobService {
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
   private final JobResultService jobResultService;
+  private final JobQueuePayloadFactory jobQueuePayloadFactory;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -72,43 +73,6 @@ public class JobService {
     if (value == null) {
       throw new IllegalArgumentException(fieldName + "은(는) 필수입니다.");
     }
-  }
-
-  private JobQueuePayload createQueuePayload(Project project, Job job) {
-    SourceType sourceType = project.getSourceType();
-
-    return switch (sourceType) {
-      case UPLOAD -> {
-        String presignedUrl = s3UploadService.generatePresignedGetUrl(project.getFileKey());
-
-        yield new JobQueuePayload(
-            job.getId(),
-            project.getId(),
-            project.getMember().getId(),
-            sourceType,
-            null,
-            project.getFileKey(),
-            presignedUrl,
-            job.getJobType(),
-            job.getSourceLanguage(),
-            job.getTargetLanguage(),
-            job.getTranslationProvider());
-      }
-
-      case YOUTUBE ->
-          new JobQueuePayload(
-              job.getId(),
-              project.getId(),
-              project.getMember().getId(),
-              sourceType,
-              project.getSourceUrl(),
-              null,
-              null,
-              job.getJobType(),
-              job.getSourceLanguage(),
-              job.getTargetLanguage(),
-              job.getTranslationProvider());
-    };
   }
 
   @Transactional(readOnly = true)
@@ -247,7 +211,7 @@ public class JobService {
   private void enqueueJob(Project project, Job job) {
     project.updateStatus(ProjectStatus.PROCESSING);
 
-    JobQueuePayload payload = createQueuePayload(project, job);
+    JobQueuePayload payload = jobQueuePayloadFactory.create(project, job);
     jobQueueProducer.enqueue(payload);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -50,6 +50,7 @@ public class JobService {
   private final ResultCopyService resultCopyService;
   private final LearningContentRepository learningContentRepository;
   private final SavedWordRepository savedWordRepository;
+  private final JobResultService jobResultService;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -212,20 +213,12 @@ public class JobService {
     job.complete(
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
-    deletePreviousResults(job.getId());
+    jobResultService.deletePreviousResults(job.getId());
     saveSegments(job, request);
     saveOcrItems(job, request);
     saveLearningContents(job, request.learningData());
 
     job.getProject().markCompleted();
-  }
-
-  private void deletePreviousResults(Long jobId) {
-    savedWordRepository.deleteByJobId(jobId);
-    segmentWordRepository.deleteBySegmentJobId(jobId);
-    segmentRepository.deleteByJobId(jobId);
-    ocrItemRepository.deleteByJobId(jobId);
-    learningContentRepository.deleteByJobId(jobId);
   }
 
   private void handleFailedCallback(Job job, JobCallbackRequest request) {

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -56,10 +56,7 @@ public class JobService {
 
   @Transactional
   public JobCreateResponse createJob(Long projectId, Long memberId, JobCreateRequest request) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     validateJobCreateRequest(request);
 
@@ -146,10 +143,7 @@ public class JobService {
 
   @Transactional(readOnly = true)
   public List<JobResponse> getJobsByProject(Long projectId, Long memberId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     return jobRepository.findByProjectIdOrderByCreatedAtDesc(project.getId()).stream()
         .map(JobResponse::from)
@@ -158,25 +152,15 @@ public class JobService {
 
   @Transactional(readOnly = true)
   public JobDetailResponse getJobDetail(Long jobId, Long memberId) {
-    Job job =
-        jobRepository
-            .findByIdAndProjectMemberId(jobId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+    Job job = findJobByIdAndMemberId(jobId, memberId);
 
     return JobDetailResponse.from(job);
   }
 
   @Transactional
   public JobRetryResponse retryJob(Long projectId, Long memberId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
-
-    Job latestJob =
-        jobRepository
-            .findTopByProjectIdOrderByCreatedAtDesc(project.getId())
-            .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
+    Job latestJob = findLatestJobByProjectId(project.getId());
 
     if (latestJob.getStatus() != JobStatus.FAILED) {
       throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
@@ -383,5 +367,23 @@ public class JobService {
             .toList();
 
     learningContentRepository.saveAll(learningContents);
+  }
+
+  private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {
+    return projectRepository
+        .findByIdAndMemberId(projectId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+  }
+
+  private Job findJobByIdAndMemberId(Long jobId, Long memberId) {
+    return jobRepository
+        .findByIdAndProjectMemberId(jobId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+  }
+
+  private Job findLatestJobByProjectId(Long projectId) {
+    return jobRepository
+        .findTopByProjectIdOrderByCreatedAtDesc(projectId)
+        .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -72,10 +72,7 @@ public class JobService {
       return JobCreateResponse.from(savedJob, true);
     }
 
-    project.updateStatus(ProjectStatus.PROCESSING);
-
-    JobQueuePayload payload = createQueuePayload(project, savedJob);
-    jobQueueProducer.enqueue(payload);
+    enqueueJob(project, savedJob);
 
     return JobCreateResponse.from(savedJob, false);
   }
@@ -160,10 +157,7 @@ public class JobService {
 
     Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob));
 
-    project.updateStatus(ProjectStatus.PROCESSING);
-
-    JobQueuePayload payload = createQueuePayload(project, savedJob);
-    jobQueueProducer.enqueue(payload);
+    enqueueJob(project, savedJob);
 
     return new JobRetryResponse(
         project.getId(),
@@ -387,5 +381,12 @@ public class JobService {
         latestJob.getSourceLanguage(),
         latestJob.getTargetLanguage(),
         latestJob.getTranslationProvider());
+  }
+
+  private void enqueueJob(Project project, Job job) {
+    project.updateStatus(ProjectStatus.PROCESSING);
+
+    JobQueuePayload payload = createQueuePayload(project, job);
+    jobQueueProducer.enqueue(payload);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -32,6 +32,7 @@ public class JobService {
   private final ResultCopyService resultCopyService;
   private final JobResultService jobResultService;
   private final JobQueuePayloadFactory jobQueuePayloadFactory;
+  private final WorkerAuthService workerAuthService;
 
   @Value("${worker.secret}")
   private String workerSecret;
@@ -112,16 +113,10 @@ public class JobService {
         "분석 재처리 요청이 생성되었습니다.");
   }
 
-  private void validateWorkerSecret(String requestWorkerSecret) {
-    if (requestWorkerSecret == null || !workerSecret.equals(requestWorkerSecret)) {
-      throw new IllegalArgumentException("Worker Secret이 일치하지 않습니다.");
-    }
-  }
-
   @Transactional
   public JobCallbackResponse handleCallback(
       Long pathJobId, String requestWorkerSecret, JobCallbackRequest request) {
-    validateWorkerSecret(requestWorkerSecret);
+    workerAuthService.validateWorkerSecret(requestWorkerSecret);
     validateCallbackJobId(pathJobId, request.jobId());
 
     Job job = findJobById(pathJobId);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -21,12 +21,8 @@ import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
 import com.overlang.domain.project.repository.ProjectRepository;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
-import com.overlang.domain.segment.entity.Segment;
-import com.overlang.domain.segment.entity.SegmentWord;
-import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -214,7 +210,7 @@ public class JobService {
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
     jobResultService.deletePreviousResults(job.getId());
-    saveSegments(job, request);
+    jobResultService.saveSegments(job, request);
     saveOcrItems(job, request);
     saveLearningContents(job, request.learningData());
 
@@ -226,28 +222,6 @@ public class JobService {
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
     job.getProject().markFailed();
-  }
-
-  private void saveSegments(Job job, JobCallbackRequest request) {
-    if (request.segments() == null) return;
-
-    List<Segment> segments =
-        request.segments().stream()
-            .map(
-                s ->
-                    new Segment(
-                        job,
-                        s.startTime(),
-                        s.endTime(),
-                        s.seq(),
-                        s.text(),
-                        s.translatedText(),
-                        s.languageCode()))
-            .toList();
-
-    List<Segment> savedSegments = segmentRepository.saveAll(segments);
-
-    saveSegmentWords(savedSegments);
   }
 
   private void saveOcrItems(Job job, JobCallbackRequest request) {
@@ -280,43 +254,6 @@ public class JobService {
         blurRegion != null ? blurRegion.y() : null,
         blurRegion != null ? blurRegion.w() : null,
         blurRegion != null ? blurRegion.h() : null);
-  }
-
-  private void saveSegmentWords(List<Segment> segments) {
-    List<SegmentWord> segmentWords =
-        segments.stream().flatMap(segment -> createWordsFromSegment(segment).stream()).toList();
-
-    segmentWordRepository.saveAll(segmentWords);
-  }
-
-  private List<SegmentWord> createWordsFromSegment(Segment segment) {
-    List<SegmentWord> words = new ArrayList<>();
-
-    words.addAll(createWordsFromText(segment, segment.getText(), SegmentWordType.ORIGINAL));
-
-    words.addAll(
-        createWordsFromText(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
-
-    return words;
-  }
-
-  private List<SegmentWord> createWordsFromText(
-      Segment segment, String text, SegmentWordType wordType) {
-
-    if (text == null || text.isBlank()) {
-      return List.of();
-    }
-
-    String[] words = text.split(WORD_SPLIT_REGEX);
-    List<SegmentWord> segmentWords = new ArrayList<>();
-
-    for (int i = 0; i < words.length; i++) {
-      segmentWords.add(
-          new SegmentWord(
-              segment, i + 1, segment.getStartTime(), segment.getEndTime(), words[i], wordType));
-    }
-
-    return segmentWords;
   }
 
   private void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -10,8 +10,6 @@ import com.overlang.domain.job.entity.JobStatus;
 import com.overlang.domain.job.queue.JobQueuePayload;
 import com.overlang.domain.job.queue.JobQueueProducer;
 import com.overlang.domain.job.repository.JobRepository;
-import com.overlang.domain.learning.entity.LearningContent;
-import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.entity.SourceType;
@@ -26,15 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class JobService {
 
-  private static final String WORD_SPLIT_REGEX = "\\s+";
-
   private final ProjectRepository projectRepository;
   private final JobRepository jobRepository;
   private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
-  private final LearningContentRepository learningContentRepository;
   private final JobResultService jobResultService;
 
   @Value("${worker.secret}")
@@ -201,7 +196,7 @@ public class JobService {
     jobResultService.deletePreviousResults(job.getId());
     jobResultService.saveSegments(job, request);
     jobResultService.saveOcrItems(job, request);
-    saveLearningContents(job, request.learningData());
+    jobResultService.saveLearningContents(job, request.learningData());
 
     job.getProject().markCompleted();
   }
@@ -211,28 +206,6 @@ public class JobService {
         request.progress(), request.currentStage(), request.errorCode(), request.errorMessage());
 
     job.getProject().markFailed();
-  }
-
-  private void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {
-    if (learningData == null || learningData.contents() == null) {
-      return;
-    }
-
-    List<LearningContent> learningContents =
-        learningData.contents().stream()
-            .map(
-                content ->
-                    new LearningContent(
-                        job,
-                        content.contentType(),
-                        content.textType(),
-                        content.title(),
-                        content.content(),
-                        content.startTime(),
-                        content.endTime()))
-            .toList();
-
-    learningContentRepository.saveAll(learningContents);
   }
 
   private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -254,7 +254,7 @@ public class JobService {
 
     List<Segment> savedSegments = segmentRepository.saveAll(segments);
 
-    createSegmentWords(savedSegments);
+    saveSegmentWords(savedSegments);
   }
 
   private void saveOcrItems(Job job, JobCallbackRequest request) {
@@ -289,26 +289,27 @@ public class JobService {
         blurRegion != null ? blurRegion.h() : null);
   }
 
-  private void createSegmentWords(List<Segment> segments) {
+  private void saveSegmentWords(List<Segment> segments) {
     List<SegmentWord> segmentWords =
-        segments.stream().flatMap(segment -> createSegmentWords(segment).stream()).toList();
+        segments.stream().flatMap(segment -> createWordsFromSegment(segment).stream()).toList();
 
     segmentWordRepository.saveAll(segmentWords);
   }
 
-  private List<SegmentWord> createSegmentWords(Segment segment) {
+  private List<SegmentWord> createWordsFromSegment(Segment segment) {
     List<SegmentWord> words = new ArrayList<>();
 
-    words.addAll(createSegmentWords(segment, segment.getText(), SegmentWordType.ORIGINAL));
+    words.addAll(createWordsFromText(segment, segment.getText(), SegmentWordType.ORIGINAL));
 
     words.addAll(
-        createSegmentWords(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
+        createWordsFromText(segment, segment.getTranslatedText(), SegmentWordType.TRANSLATION));
 
     return words;
   }
 
-  private List<SegmentWord> createSegmentWords(
+  private List<SegmentWord> createWordsFromText(
       Segment segment, String text, SegmentWordType wordType) {
+
     if (text == null || text.isBlank()) {
       return List.of();
     }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -60,15 +60,7 @@ public class JobService {
 
     validateJobCreateRequest(request);
 
-    Job job =
-        new Job(
-            project,
-            request.jobType(),
-            request.sourceLanguage(),
-            request.targetLanguage(),
-            request.translationProvider());
-
-    Job savedJob = jobRepository.save(job);
+    Job savedJob = jobRepository.save(createJobEntity(project, request));
 
     var reusableJob = resultCacheService.findReusableJob(project, request);
 
@@ -166,15 +158,7 @@ public class JobService {
       throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
     }
 
-    Job retryJob =
-        new Job(
-            project,
-            latestJob.getJobType(),
-            latestJob.getSourceLanguage(),
-            latestJob.getTargetLanguage(),
-            latestJob.getTranslationProvider());
-
-    Job savedJob = jobRepository.save(retryJob);
+    Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob));
 
     project.updateStatus(ProjectStatus.PROCESSING);
 
@@ -385,5 +369,23 @@ public class JobService {
     return jobRepository
         .findTopByProjectIdOrderByCreatedAtDesc(projectId)
         .orElseThrow(() -> new IllegalArgumentException("재처리할 작업이 없습니다."));
+  }
+
+  private Job createJobEntity(Project project, JobCreateRequest request) {
+    return new Job(
+        project,
+        request.jobType(),
+        request.sourceLanguage(),
+        request.targetLanguage(),
+        request.translationProvider());
+  }
+
+  private Job createRetryJobEntity(Project project, Job latestJob) {
+    return new Job(
+        project,
+        latestJob.getJobType(),
+        latestJob.getSourceLanguage(),
+        latestJob.getTargetLanguage(),
+        latestJob.getTranslationProvider());
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/service/WorkerAuthService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/WorkerAuthService.java
@@ -1,0 +1,19 @@
+package com.overlang.domain.job.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WorkerAuthService {
+
+  @Value("${worker.secret}")
+  private String workerSecret;
+
+  public void validateWorkerSecret(String requestWorkerSecret) {
+    if (requestWorkerSecret == null || !workerSecret.equals(requestWorkerSecret)) {
+      throw new IllegalArgumentException("Worker Secret이 일치하지 않습니다.");
+    }
+  }
+}


### PR DESCRIPTION
## 작업 개요
- JobService의 책임을 분리하고 관련 로직을 별도 서비스/팩토리로 이동하여 구조 개선

## 관련 이슈
- close #127

## 작업 내용
- callback 결과 삭제 로직을 JobResultService로 이동
- Segment 및 SegmentWord 저장 로직을 JobResultService로 이동
- OCR 결과 저장 로직을 JobResultService로 이동
- LearningContent 저장 로직을 JobResultService로 이동
- JobQueuePayload 생성 로직을 JobQueuePayloadFactory로 분리
- Worker Secret 검증 로직을 WorkerAuthService로 분리
- JobService가 Job 흐름 제어에 집중하도록 책임 정리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- Job 생성, 재처리, COMPLETED callback, Worker Secret 검증, Job 상세 조회 정상 동작 확인 완료
- 기능 변경 없이 서비스 책임 분리 및 코드 구조 개선만 진행