### PR TITLE
feat: SavedWordResponse에 segmentId 추가

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordResponse.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 public record SavedWordResponse(
     Long savedWordId,
     Long segmentWordId,
+    Long segmentId,
     String word,
     SelectedTextType selectedTextType,
     String meaning,
@@ -30,6 +31,7 @@ public record SavedWordResponse(
     return new SavedWordResponse(
         savedWord.getId(),
         segmentWord.getId(),
+        segment.getId(),
         savedWord.getWord(),
         SelectedTextType.valueOf(segmentWord.getWordType().name()),
         savedWord.getMeaning(),


### PR DESCRIPTION
## 작업 개요
- SavedWordResponse에 segmentId 필드를 추가하여 학습 노트에서도 explainWord API를 호출할 수 있도록 개선

## 관련 이슈
- close #135

## 작업 내용
- SavedWordResponse에 segmentId 필드 추가
- SavedWordResponse 생성 시 SegmentWord와 연결된 Segment의 id 반환
- 저장 단어 조회 API 응답에 segmentId 포함되도록 수정
- Swagger 및 API 응답 테스트 확인

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- StudyPage에서 explainWord 호출 시 필요한 segmentId를 SavedWordResponse에서 제공하도록 수정
- 기존 segmentWordId 응답 구조는 유지