### PR TITLE
feat: OCR 스타일 정보 및 애니메이션 필드 추가

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -60,8 +60,27 @@ public class InternalJobController {
                                 "w": 0.3,
                                 "h": 0.4
                               },
-                              "confidence": 0.95
-                            }
+                              "confidence": 0.95,
+                              "style": {
+                                                  "backgroundColor": "#1A1A1A",
+                                                  "dominantBackgroundColor": "#202020",
+                                                  "textColor": "#FFFFFF",
+                                                  "fontSizeRatio": 0.045,
+                                                  "fontWeight": "BOLD",
+                                                  "textAlign": "CENTER",
+                                                  "blurRegion": {
+                                                    "x": 0.1,
+                                                    "y": 0.2,
+                                                    "w": 0.3,
+                                                    "h": 0.4
+                                                  },
+                                                  "animation": {
+                                                    "type": "TYPEWRITER",
+                                                    "startTime": 1.0,
+                                                    "endTime": 2.0
+                                                  }
+                                                }
+                             }
                           ],
                           "learningData": {
                            "contents": [

--- a/backend/src/main/java/com/overlang/api/dto/ocr/AnimationRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/AnimationRequest.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record AnimationRequest(String type, Double startTime, Double endTime) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/AnimationResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/AnimationResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record AnimationResponse(String type, Double startTime, Double endTime) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
@@ -27,7 +27,16 @@ public record OcrItemResponse(
             ocrItem.getBackgroundColor(),
             ocrItem.getDominantBackgroundColor(),
             ocrItem.getTextColor(),
+            ocrItem.getFontSizeRatio(),
+            ocrItem.getFontWeight(),
+            ocrItem.getTextAlign(),
             new BlurRegionResponse(
-                ocrItem.getBlurX(), ocrItem.getBlurY(), ocrItem.getBlurW(), ocrItem.getBlurH())));
+                ocrItem.getBlurX(), ocrItem.getBlurY(), ocrItem.getBlurW(), ocrItem.getBlurH()),
+            ocrItem.getAnimationType() != null
+                ? new AnimationResponse(
+                    ocrItem.getAnimationType(),
+                    ocrItem.getAnimationStartTime(),
+                    ocrItem.getAnimationEndTime())
+                : null));
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleRequest.java
@@ -4,4 +4,8 @@ public record OcrStyleRequest(
     String backgroundColor,
     String dominantBackgroundColor,
     String textColor,
-    BlurRegionRequest blurRegion) {}
+    Double fontSizeRatio,
+    String fontWeight,
+    String textAlign,
+    BlurRegionRequest blurRegion,
+    AnimationRequest animation) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrStyleResponse.java
@@ -4,4 +4,8 @@ public record OcrStyleResponse(
     String backgroundColor,
     String dominantBackgroundColor,
     String textColor,
-    BlurRegionResponse blurRegion) {}
+    Double fontSizeRatio,
+    String fontWeight,
+    String textAlign,
+    BlurRegionResponse blurRegion,
+    AnimationResponse animation) {}

--- a/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
+++ b/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
@@ -68,7 +68,13 @@ public class ResultCopyService {
                         item.getBlurX(),
                         item.getBlurY(),
                         item.getBlurW(),
-                        item.getBlurH()))
+                        item.getBlurH(),
+                        item.getFontSizeRatio(),
+                        item.getFontWeight(),
+                        item.getTextAlign(),
+                        item.getAnimationType(),
+                        item.getAnimationStartTime(),
+                        item.getAnimationEndTime()))
             .toList();
 
     ocrItemRepository.saveAll(copiedOcrItems);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -195,7 +195,25 @@ public class JobResultService {
         blurRegion != null ? blurRegion.x() : null,
         blurRegion != null ? blurRegion.y() : null,
         blurRegion != null ? blurRegion.w() : null,
-        blurRegion != null ? blurRegion.h() : null);
+        blurRegion != null ? blurRegion.h() : null,
+        style != null ? style.fontSizeRatio() : null,
+        style != null ? style.fontWeight() : null,
+        style != null ? style.textAlign() : null,
+        getAnimationType(style),
+        getAnimationStartTime(style),
+        getAnimationEndTime(style));
+  }
+
+  private String getAnimationType(OcrStyleRequest style) {
+    return style != null && style.animation() != null ? style.animation().type() : null;
+  }
+
+  private Double getAnimationStartTime(OcrStyleRequest style) {
+    return style != null && style.animation() != null ? style.animation().startTime() : null;
+  }
+
+  private Double getAnimationEndTime(OcrStyleRequest style) {
+    return style != null && style.animation() != null ? style.animation().endTime() : null;
   }
 
   public void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {

--- a/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
@@ -66,6 +66,24 @@ public class OcrItem extends BaseTimeEntity {
   @Column(name = "blur_h")
   private Double blurH;
 
+  @Column(name = "font_size_ratio")
+  private Double fontSizeRatio;
+
+  @Column(name = "font_weight", length = 20)
+  private String fontWeight;
+
+  @Column(name = "text_align", length = 20)
+  private String textAlign;
+
+  @Column(name = "animation_type", length = 30)
+  private String animationType;
+
+  @Column(name = "animation_start_time")
+  private Double animationStartTime;
+
+  @Column(name = "animation_end_time")
+  private Double animationEndTime;
+
   public OcrItem(
       Job job,
       Double startTime,
@@ -83,7 +101,13 @@ public class OcrItem extends BaseTimeEntity {
       Double blurX,
       Double blurY,
       Double blurW,
-      Double blurH) {
+      Double blurH,
+      Double fontSizeRatio,
+      String fontWeight,
+      String textAlign,
+      String animationType,
+      Double animationStartTime,
+      Double animationEndTime) {
     this.job = job;
     this.startTime = startTime;
     this.endTime = endTime;
@@ -101,5 +125,11 @@ public class OcrItem extends BaseTimeEntity {
     this.blurY = blurY;
     this.blurW = blurW;
     this.blurH = blurH;
+    this.fontSizeRatio = fontSizeRatio;
+    this.fontWeight = fontWeight;
+    this.textAlign = textAlign;
+    this.animationType = animationType;
+    this.animationStartTime = animationStartTime;
+    this.animationEndTime = animationEndTime;
   }
 }


### PR DESCRIPTION
## 작업 개요
- OCR 번역 결과에 스타일 및 애니메이션 정보를 저장하고 조회할 수 있도록 구조 확장

## 관련 이슈
- close #137

## 작업 내용
- OCR style request/response DTO 확장
- animation request/response DTO 추가
- OcrItem Entity에 OCR 스타일 관련 필드 추가
- OCR callback 저장 로직에 style 정보 저장 처리 추가
- OCR 조회 API 응답에 style 및 animation 정보 포함
- Swagger callback 예시 업데이트
- OCR style 저장 및 조회 테스트 완료

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- blurRegion, animation 등 nullable 스타일 정보 지원