### PR TITLE
feat: 저장 단어 예문 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/SavedWordController.java
+++ b/backend/src/main/java/com/overlang/api/controller/SavedWordController.java
@@ -1,6 +1,7 @@
 package com.overlang.api.controller;
 
 import com.overlang.api.dto.savedword.SavedWordCreateRequest;
+import com.overlang.api.dto.savedword.SavedWordExampleResponse;
 import com.overlang.api.dto.savedword.SavedWordResponse;
 import com.overlang.domain.savedword.service.SavedWordService;
 import com.overlang.global.auth.AuthInterceptor;
@@ -40,5 +41,13 @@ public class SavedWordController {
     Long memberId = (Long) httpRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
     savedWordService.deleteSavedWord(memberId, savedWordId);
     return ApiResponse.success(null);
+  }
+
+  @Operation(summary = "저장 단어 AI 예문 생성", description = "학습노트에 저장된 단어를 기반으로 AI 예문을 생성합니다.")
+  @PostMapping("/me/saved-words/{savedWordId}/examples")
+  public ApiResponse<SavedWordExampleResponse> generateExamples(
+      HttpServletRequest httpRequest, @PathVariable Long savedWordId) {
+    Long memberId = (Long) httpRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+    return ApiResponse.success(savedWordService.generateExamples(memberId, savedWordId));
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordExampleResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/savedword/SavedWordExampleResponse.java
@@ -1,0 +1,7 @@
+package com.overlang.api.dto.savedword;
+
+import java.util.List;
+
+public record SavedWordExampleResponse(Long savedWordId, String word, List<ExampleItem> examples) {
+  public record ExampleItem(String sentence, String translatedSentence) {}
+}

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -47,4 +47,6 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
           WHERE sw.segmentWord.segment.job.id = :jobId
           """)
   void deleteByJobId(@Param("jobId") Long jobId);
+
+  Optional<SavedWord> findByIdAndMember_Id(Long id, Long memberId);
 }

--- a/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
@@ -1,6 +1,7 @@
 package com.overlang.domain.savedword.service;
 
 import com.overlang.api.dto.savedword.SavedWordCreateRequest;
+import com.overlang.api.dto.savedword.SavedWordExampleResponse;
 import com.overlang.api.dto.savedword.SavedWordResponse;
 import com.overlang.domain.member.entity.Member;
 import com.overlang.domain.member.repository.MemberRepository;
@@ -8,6 +9,7 @@ import com.overlang.domain.savedword.entity.SavedWord;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
+import com.overlang.domain.word.service.WordsExplainService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ public class SavedWordService {
   private final SavedWordRepository savedWordRepository;
   private final MemberRepository memberRepository;
   private final SegmentWordRepository segmentWordRepository;
+  private final WordsExplainService wordsExplainService;
 
   @Transactional
   public SavedWordResponse createSavedWord(Long memberId, SavedWordCreateRequest request) {
@@ -72,5 +75,15 @@ public class SavedWordService {
             .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
 
     savedWordRepository.delete(savedWord);
+  }
+
+  @Transactional(readOnly = true)
+  public SavedWordExampleResponse generateExamples(Long memberId, Long savedWordId) {
+    SavedWord savedWord =
+        savedWordRepository
+            .findByIdAndMemberId(savedWordId, memberId)
+            .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
+
+    return wordsExplainService.generateExamples(savedWord);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainService.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainService.java
@@ -1,9 +1,13 @@
 package com.overlang.domain.word.service;
 
+import com.overlang.api.dto.savedword.SavedWordExampleResponse;
 import com.overlang.api.dto.word.WordsExplainRequest;
 import com.overlang.api.dto.word.WordsExplainResponse;
+import com.overlang.domain.savedword.entity.SavedWord;
 
 public interface WordsExplainService {
 
   WordsExplainResponse explain(WordsExplainRequest request);
+
+  SavedWordExampleResponse generateExamples(SavedWord savedWord);
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -2,11 +2,13 @@ package com.overlang.domain.word.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.overlang.api.dto.savedword.SavedWordExampleResponse;
 import com.overlang.api.dto.word.WordsExplainRequest;
 import com.overlang.api.dto.word.WordsExplainResponse;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.entity.LearningContentType;
 import com.overlang.domain.learning.repository.LearningContentRepository;
+import com.overlang.domain.savedword.entity.SavedWord;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import java.util.Comparator;
@@ -41,7 +43,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
       LearningContent expression = matchedExpression.get();
 
       List<String> relatedWords =
-          generateRelatedWords(expression.getTitle(), getSelectedTextLanguage(request));
+          generateRelatedWords(expression.getTitle(), getRelatedWordsLanguage(request));
 
       return new WordsExplainResponse(
           expression.getTitle(), expression.getContent(), relatedWords, true);
@@ -83,8 +85,8 @@ public class WordsExplainServiceImpl implements WordsExplainService {
       선택 단어 언어: %s
 
       규칙:
-      - meaning은 선택 단어 언어로 작성
-      - relatedWords는 선택 단어 언어로 작성
+      - meaning은 %s 언어로 작성
+      - relatedWords는 %s 언어로 작성
       - relatedWords는 선택 단어와 유사한 의미의 단어 또는 표현 3개를 작성
       - relatedWords는 사전식 유의어 또는 비슷한 의미의 표현 위주로 작성
       - 단순 연관어(카테고리, 분야 단어)는 제외
@@ -103,7 +105,9 @@ public class WordsExplainServiceImpl implements WordsExplainService {
             request.translatedSentence(),
             request.sourceLanguage(),
             request.targetLanguage(),
-            getSelectedTextLanguage(request));
+            getSelectedTextLanguage(request),
+            request.targetLanguage(),
+            getRelatedWordsLanguage(request));
   }
 
   @SuppressWarnings("unchecked")
@@ -162,6 +166,13 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     return value.toLowerCase().replaceAll(NON_WORD_REGEX, "").trim();
   }
 
+  private String getRelatedWordsLanguage(WordsExplainRequest request) {
+    return switch (request.selectedTextType()) {
+      case ORIGINAL -> request.sourceLanguage();
+      case TRANSLATION -> request.targetLanguage();
+    };
+  }
+
   private List<String> generateRelatedWords(String expression, String targetLanguage) {
 
     String prompt =
@@ -208,4 +219,61 @@ public class WordsExplainServiceImpl implements WordsExplainService {
       case TRANSLATION -> request.targetLanguage();
     };
   }
+
+  @Override
+  public SavedWordExampleResponse generateExamples(SavedWord savedWord) {
+
+    String prompt = createExamplePrompt(savedWord);
+
+    Map<String, Object> body =
+        Map.of(
+            "model", model,
+            "input", prompt,
+            "store", false);
+
+    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
+
+    String outputText = extractOutputText(response);
+
+    try {
+      ExampleResult result = objectMapper.readValue(outputText, ExampleResult.class);
+
+      return new SavedWordExampleResponse(
+          savedWord.getId(), savedWord.getWord(), result.examples());
+
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("OpenAI 예문 응답 파싱에 실패했습니다.", e);
+    }
+  }
+
+  private String createExamplePrompt(SavedWord savedWord) {
+
+    String targetLanguage =
+        savedWord.getSegmentWord().getSegment().getJob().getTargetLanguage().name();
+
+    return """
+    사용자가 저장한 단어를 기반으로 자연스러운 예문 3개를 생성하세요.
+
+    저장 단어: %s
+    번역 언어: %s
+
+    규칙:
+    - sentence는 저장 단어와 같은 언어로 작성
+    - translatedSentence는 %s 언어로 작성
+    - 설명 문장 없이 JSON만 반환
+
+    JSON 형식:
+    {
+      "examples": [
+        {
+          "sentence": "example sentence",
+          "translatedSentence": "예문 번역"
+        }
+      ]
+    }
+    """
+        .formatted(savedWord.getWord(), targetLanguage, targetLanguage);
+  }
+
+  private record ExampleResult(List<SavedWordExampleResponse.ExampleItem> examples) {}
 }


### PR DESCRIPTION
## 작업 개요
- 학습노트에 저장된 단어를 기반으로 AI 예문을 생성하는 API 구현

## 관련 이슈
- close #139

## 작업 내용
- 저장 단어 AI 예문 생성 API 추가
- `POST /api/v1/me/saved-words/{savedWordId}/examples` 엔드포인트 구현
- 저장 단어 조회 및 사용자 검증 로직 추가
- OpenAI 기반 예문 생성 기능 구현
- 저장 단어 언어 기준으로 예문 생성, 번역 언어 기준으로 예문 번역 반환하도록 프롬프트 개선
- 예문 응답 구조를 `sentence`, `translatedSentence` 형태로 구성
- 단어 설명 API 다국어 생성 로직 개선
- ORIGINAL 선택 시 뜻은 번역 언어, 유의어는 원문 언어로 생성 처리
- TRANSLATION 선택 시 뜻과 유의어 모두 번역 언어로 생성 처리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 예문 데이터는 DB에 저장하지 않고 OpenAI 생성 결과를 실시간 반환하는 방식으로 구현