### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/MemberController.java
+++ b/backend/src/main/java/com/overlang/api/controller/MemberController.java
@@ -1,17 +1,17 @@
 package com.overlang.api.controller;
 
+import com.overlang.api.dto.member.MemberWithdrawResponse;
 import com.overlang.api.dto.member.ProfileImageUploadResponse;
 import com.overlang.domain.member.service.MemberService;
+import com.overlang.domain.member.service.MemberWithdrawService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -20,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
   private final MemberService memberService;
+  private final MemberWithdrawService memberWithdrawService;
 
   @Operation(summary = "프로필 이미지 업로드", description = "현재 로그인한 사용자의 프로필 이미지를 업로드합니다.")
   @PostMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -29,5 +30,16 @@ public class MemberController {
     Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
 
     return ApiResponse.success(memberService.uploadProfileImage(memberId, file));
+  }
+
+  @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정과 관련 데이터를 삭제합니다.")
+  @DeleteMapping("/me")
+  public ApiResponse<MemberWithdrawResponse> withdraw(HttpServletRequest httpServletRequest) {
+
+    Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
+
+    memberWithdrawService.withdraw(memberId);
+
+    return ApiResponse.success(new MemberWithdrawResponse(memberId, true));
   }
 }

--- a/backend/src/main/java/com/overlang/api/dto/member/MemberWithdrawResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/member/MemberWithdrawResponse.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.member;
+
+public record MemberWithdrawResponse(Long memberId, boolean deleted) {}

--- a/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
+++ b/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
@@ -1,0 +1,53 @@
+package com.overlang.domain.member.service;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.overlang.domain.file.service.S3UploadService;
+import com.overlang.domain.member.entity.Member;
+import com.overlang.domain.member.repository.MemberRepository;
+import com.overlang.domain.project.entity.Project;
+import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.domain.project.service.ProjectService;
+import com.overlang.domain.savedword.repository.SavedWordRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberWithdrawService {
+
+  private final MemberRepository memberRepository;
+  private final ProjectRepository projectRepository;
+  private final ProjectService projectService;
+  private final SavedWordRepository savedWordRepository;
+  private final S3UploadService s3UploadService;
+
+  public void withdraw(Long memberId) {
+
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+    List<Project> projects = projectRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+    for (Project project : projects) {
+      projectService.deleteProject(memberId, project.getId());
+    }
+
+    savedWordRepository.deleteByMemberId(memberId);
+
+    s3UploadService.deleteFileByUrl(member.getProfileImageUrl());
+
+    try {
+      FirebaseAuth.getInstance().deleteUser(member.getFirebaseUid());
+    } catch (FirebaseAuthException e) {
+      throw new IllegalArgumentException("Firebase 회원 삭제 중 오류가 발생했습니다.");
+    }
+
+    memberRepository.delete(member);
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -49,4 +49,11 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
   void deleteByJobId(@Param("jobId") Long jobId);
 
   Optional<SavedWord> findByIdAndMember_Id(Long id, Long memberId);
+
+  @Modifying
+  @Query("""
+    DELETE FROM SavedWord sw
+    WHERE sw.member.id = :memberId
+    """)
+  void deleteByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 작업 개요
회원 탈퇴 API를 구현하고 사용자 관련 데이터 및 Firebase 계정을 함께 삭제하도록 처리

## 관련 이슈
- close #144

## 작업 내용
- `DELETE /api/v1/members/me` 회원 탈퇴 API 구현
- 회원 탈퇴 시 프로젝트 삭제 로직 재사용 구조 적용
- 프로젝트 연관 데이터(job, segment, segment_word, saved_word 등) 삭제 처리
- 업로드 영상 S3 파일 삭제 처리
- 프로필 이미지 S3 파일 삭제 처리
- Firebase Auth 계정 삭제 처리
- Member 삭제 처리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항