### PR TITLE
feat: 일본어 및 중국어 형태소 분석 기반 단어 처리 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.2.0'
     implementation 'software.amazon.awssdk:s3:2.25.20'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.atilika.kuromoji:kuromoji-ipadic:0.9.0'
+    implementation 'com.huaban:jieba-analysis:1.0.2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -8,6 +8,7 @@ import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.ocr.OcrStyleRequest;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
+import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.entity.LearningContent;
@@ -20,6 +21,7 @@ import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
+import com.overlang.domain.segment.tokenizer.SegmentWordTokenizerProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,7 @@ public class JobResultService {
   private final JobRepository jobRepository;
   private final LearningContentRepository learningContentRepository;
   private final SavedWordRepository savedWordRepository;
+  private final SegmentWordTokenizerProvider tokenizerProvider;
 
   @Transactional(readOnly = true)
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
@@ -105,8 +108,6 @@ public class JobResultService {
     learningContentRepository.deleteByJobId(jobId);
   }
 
-  private static final String WORD_SPLIT_REGEX = "\\s+";
-
   public void saveSegments(Job job, JobCallbackRequest request) {
     if (request.segments() == null) return;
 
@@ -154,15 +155,21 @@ public class JobResultService {
       return List.of();
     }
 
-    String[] words = text.split(WORD_SPLIT_REGEX);
+    List<String> words =
+        tokenizerProvider.tokenize(text, LanguageCode.fromCode(segment.getLanguageCode()));
+
     List<SegmentWord> segmentWords = new ArrayList<>();
 
-    for (int i = 0; i < words.length; i++) {
+    for (int i = 0; i < words.size(); i++) {
       segmentWords.add(
           new SegmentWord(
-              segment, i + 1, segment.getStartTime(), segment.getEndTime(), words[i], wordType));
+              segment,
+              i + 1,
+              segment.getStartTime(),
+              segment.getEndTime(),
+              words.get(i),
+              wordType));
     }
-
     return segmentWords;
   }
 

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.segment.tokenizer;
+
+public class ChineseSegmentWordTokenizer {
+}

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
@@ -1,4 +1,30 @@
 package com.overlang.domain.segment.tokenizer;
 
-public class ChineseSegmentWordTokenizer {
+import com.huaban.analysis.jieba.JiebaSegmenter;
+import com.overlang.domain.common.LanguageCode;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChineseSegmentWordTokenizer implements SegmentWordTokenizer {
+
+  private final JiebaSegmenter segmenter = new JiebaSegmenter();
+
+  @Override
+  public boolean supports(LanguageCode languageCode) {
+    return languageCode == LanguageCode.ZH;
+  }
+
+  @Override
+  public List<String> tokenize(String text) {
+    if (text == null || text.isBlank()) {
+      return List.of();
+    }
+
+    return segmenter.sentenceProcess(text).stream().filter(this::isValidWord).toList();
+  }
+
+  private boolean isValidWord(String word) {
+    return word != null && !word.isBlank();
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
@@ -1,4 +1,34 @@
 package com.overlang.domain.segment.tokenizer;
 
-public class JapaneseSegmentWordTokenizer {
+import com.atilika.kuromoji.ipadic.Token;
+import com.atilika.kuromoji.ipadic.Tokenizer;
+import com.overlang.domain.common.LanguageCode;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JapaneseSegmentWordTokenizer implements SegmentWordTokenizer {
+
+  private final Tokenizer tokenizer = new Tokenizer();
+
+  @Override
+  public boolean supports(LanguageCode languageCode) {
+    return languageCode == LanguageCode.JA;
+  }
+
+  @Override
+  public List<String> tokenize(String text) {
+    if (text == null || text.isBlank()) {
+      return List.of();
+    }
+
+    return tokenizer.tokenize(text).stream()
+        .map(Token::getSurface)
+        .filter(this::isValidWord)
+        .toList();
+  }
+
+  private boolean isValidWord(String word) {
+    return word != null && !word.isBlank();
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.segment.tokenizer;
+
+public class JapaneseSegmentWordTokenizer {
+}

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
@@ -1,11 +1,11 @@
 package com.overlang.domain.segment.tokenizer;
 
-import com.overlang.domain.job.entity.LanguageCode;
+import com.overlang.domain.common.LanguageCode;
 import java.util.List;
 
 public interface SegmentWordTokenizer {
 
-    boolean supports(LanguageCode languageCode);
+  boolean supports(LanguageCode languageCode);
 
-    List<String> tokenize(String text);
+  List<String> tokenize(String text);
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
@@ -1,0 +1,11 @@
+package com.overlang.domain.segment.tokenizer;
+
+import com.overlang.domain.job.entity.LanguageCode;
+import java.util.List;
+
+public interface SegmentWordTokenizer {
+
+    boolean supports(LanguageCode languageCode);
+
+    List<String> tokenize(String text);
+}

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizerProvider.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizerProvider.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.segment.tokenizer;
+
+public class SegmentWordTokenizerProvider {
+}

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizerProvider.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizerProvider.java
@@ -1,4 +1,24 @@
 package com.overlang.domain.segment.tokenizer;
 
+import com.overlang.domain.common.LanguageCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class SegmentWordTokenizerProvider {
+
+  private final List<SegmentWordTokenizer> tokenizers;
+
+  public List<String> tokenize(String text, LanguageCode languageCode) {
+    return getTokenizer(languageCode).tokenize(text);
+  }
+
+  private SegmentWordTokenizer getTokenizer(LanguageCode languageCode) {
+    return tokenizers.stream()
+        .filter(tokenizer -> tokenizer.supports(languageCode))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 언어입니다: " + languageCode));
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
@@ -1,4 +1,32 @@
 package com.overlang.domain.segment.tokenizer;
 
-public class WhitespaceSegmentWordTokenizer {
+import com.overlang.domain.common.LanguageCode;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WhitespaceSegmentWordTokenizer implements SegmentWordTokenizer {
+
+  private static final String WORD_SPLIT_REGEX = "\\s+";
+
+  @Override
+  public boolean supports(LanguageCode languageCode) {
+    return EnumSet.of(LanguageCode.KO, LanguageCode.EN, LanguageCode.ES, LanguageCode.FR)
+        .contains(languageCode);
+  }
+
+  @Override
+  public List<String> tokenize(String text) {
+    if (text == null || text.isBlank()) {
+      return List.of();
+    }
+
+    return Arrays.stream(text.trim().split(WORD_SPLIT_REGEX)).filter(this::isValidWord).toList();
+  }
+
+  private boolean isValidWord(String word) {
+    return word != null && !word.isBlank();
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
@@ -1,0 +1,4 @@
+package com.overlang.domain.segment.tokenizer;
+
+public class WhitespaceSegmentWordTokenizer {
+}

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.overlang.api.dto.savedword.SavedWordExampleResponse;
 import com.overlang.api.dto.word.WordsExplainRequest;
 import com.overlang.api.dto.word.WordsExplainResponse;
+import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.entity.LearningContentType;
 import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.savedword.entity.SavedWord;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.repository.SegmentRepository;
+import com.overlang.domain.segment.tokenizer.SegmentWordTokenizerProvider;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -24,13 +26,13 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class WordsExplainServiceImpl implements WordsExplainService {
 
-  private static final String WORD_SPLIT_REGEX = "\\s+";
-  private static final String NON_WORD_REGEX = "[^\\p{IsAlphabetic}\\p{IsDigit}\\s]";
+  private static final String NON_WORD_REGEX = "[\\p{Punct}\\p{IsPunctuation}]";
 
   private final RestClient openAiRestClient;
   private final ObjectMapper objectMapper;
   private final SegmentRepository segmentRepository;
   private final LearningContentRepository learningContentRepository;
+  private final SegmentWordTokenizerProvider tokenizerProvider;
 
   @Value("${openai.model}")
   private String model;
@@ -135,7 +137,10 @@ public class WordsExplainServiceImpl implements WordsExplainService {
         .stream()
         .filter(expression -> expression.getTextType() == request.selectedTextType())
         .filter(expression -> overlapsSegmentTime(segment, expression))
-        .filter(expression -> containsClickedWord(expression.getTitle(), clickedWord))
+        .filter(
+            expression ->
+                containsClickedWord(
+                    expression.getTitle(), clickedWord, getSelectedTextLanguageCode(request)))
         .max(Comparator.comparingInt(expression -> expression.getTitle().length()));
   }
 
@@ -148,14 +153,17 @@ public class WordsExplainServiceImpl implements WordsExplainService {
         && expression.getEndTime() >= segment.getStartTime();
   }
 
-  private boolean containsClickedWord(String expressionTitle, String clickedWord) {
+  private boolean containsClickedWord(
+      String expressionTitle, String clickedWord, LanguageCode languageCode) {
     if (expressionTitle == null || clickedWord == null || clickedWord.isBlank()) {
       return false;
     }
 
     String normalizedTitle = normalize(expressionTitle);
 
-    return List.of(normalizedTitle.split(WORD_SPLIT_REGEX)).contains(clickedWord);
+    return tokenizerProvider.tokenize(normalizedTitle, languageCode).stream()
+        .map(this::normalize)
+        .anyMatch(clickedWord::equals);
   }
 
   private String normalize(String value) {
@@ -171,6 +179,10 @@ public class WordsExplainServiceImpl implements WordsExplainService {
       case ORIGINAL -> request.sourceLanguage();
       case TRANSLATION -> request.targetLanguage();
     };
+  }
+
+  private LanguageCode getSelectedTextLanguageCode(WordsExplainRequest request) {
+    return LanguageCode.fromCode(getSelectedTextLanguage(request));
   }
 
   private List<String> generateRelatedWords(String expression, String targetLanguage) {


### PR DESCRIPTION
## 작업 개요
일본어/중국어처럼 공백으로 단어 분리가 어려운 언어에서도 단어 클릭, 단어 설명, 단어 저장, 관용/숙어 표현 매칭이 가능하도록 언어별 SegmentWord 토큰화 로직 개선

## 관련 이슈
- close #146

## 작업 내용
- 언어별 SegmentWord tokenizer 구조 추가
- 일본어 Kuromoji 기반 SegmentWord 생성 지원
- 중국어 Jieba 기반 SegmentWord 생성 지원
- 기존 공백 split 기반 SegmentWord 생성 로직을 tokenizer 기반으로 개선
- expression 매칭 로직에 언어별 tokenizer 적용
- 일본어/중국어 단일 단어 클릭 및 관용/숙어 표현 매칭 테스트 완료
- 일본어/중국어 단어 저장 테스트 완료

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
