### PR TITLE
feat: 프로젝트 다중 선택 삭제 / 예문 생성

### DIFF
--- a/frontend/src/api/words.ts
+++ b/frontend/src/api/words.ts
@@ -81,3 +81,22 @@ export async function deleteSavedWord(savedWordId: number): Promise<void> {
   const res = await apiDelete(`/v1/saved-words/${savedWordId}`);
   if (!res.ok) throw new Error(`단어 삭제 실패 (${res.status})`);
 }
+
+export interface ExampleItem {
+  sentence: string;
+  translatedSentence: string;
+}
+
+export interface SavedWordExampleResponse {
+  savedWordId: number;
+  word: string;
+  examples: ExampleItem[];
+}
+
+/** POST /api/v1/me/saved-words/{savedWordId}/examples — AI 예문 생성 */
+export async function generateWordExamples(savedWordId: number): Promise<SavedWordExampleResponse> {
+  const res = await apiPost(`/v1/me/saved-words/${savedWordId}/examples`, {});
+  if (!res.ok) throw new Error(`예문 생성 실패 (${res.status})`);
+  const json = await res.json();
+  return json.data ?? json;
+}

--- a/frontend/src/app/pages/DashboardPage.tsx
+++ b/frontend/src/app/pages/DashboardPage.tsx
@@ -80,6 +80,44 @@ export function DashboardPage() {
   // 재시도
   const [retryingId, setRetryingId] = useState<number | null>(null);
 
+  // 선택 삭제 모드
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [bulkDeleteLoading, setBulkDeleteLoading] = useState(false);
+
+  const toggleSelect = (pid: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      next.has(pid) ? next.delete(pid) : next.add(pid);
+      return next;
+    });
+  };
+
+  const handleBulkDelete = async () => {
+    if (selectedIds.size === 0) return;
+    if (!confirm(`선택한 ${selectedIds.size}개 프로젝트를 삭제할까요? 이 작업은 되돌릴 수 없습니다.`)) return;
+    setBulkDeleteLoading(true);
+    try {
+      await Promise.allSettled(
+        Array.from(selectedIds).map(async pid => {
+          try {
+            const savedWords = await getMySavedWords();
+            const projectWords = savedWords.filter(w => w.projectId === pid);
+            await Promise.allSettled(projectWords.map(w => deleteSavedWord(w.savedWordId)));
+          } catch { /* ignore */ }
+          await deleteProject(pid);
+        })
+      );
+      setProjects(prev => prev.filter(p => !selectedIds.has(p.id ?? p.projectId ?? -1)));
+      setSelectedIds(new Set());
+      setSelectMode(false);
+    } catch {
+      alert('일부 프로젝트 삭제에 실패했습니다.');
+    } finally {
+      setBulkDeleteLoading(false);
+    }
+  };
+
   // 분석 중 클릭 시 안내 토스트
   const [processingToast, setProcessingToast] = useState(false);
   const showProcessingToast = () => {
@@ -214,21 +252,52 @@ export function DashboardPage() {
 
       <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
 
-        {/* 타이틀 + 업로드 버튼 */}
+        {/* 타이틀 + 버튼 영역 */}
         <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="text-2xl font-bold text-slate-800">내 영상</h1>
             <p className="text-sm text-slate-400 mt-1">업로드한 영상과 번역 결과를 확인하세요</p>
           </div>
-          <button
-            onClick={() => navigate('/upload')}
-            className="flex items-center gap-2 px-4 py-2.5 bg-emerald-600 text-white rounded-xl font-semibold text-sm hover:bg-emerald-700 transition-colors"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            새 영상 업로드
-          </button>
+          <div className="flex items-center gap-2">
+            {selectMode ? (
+              <>
+                <span className="text-sm text-slate-500">{selectedIds.size}개 선택됨</span>
+                <button
+                  onClick={handleBulkDelete}
+                  disabled={selectedIds.size === 0 || bulkDeleteLoading}
+                  className="flex items-center gap-2 px-4 py-2.5 bg-red-500 text-white rounded-xl font-semibold text-sm hover:bg-red-400 disabled:opacity-40 transition-colors"
+                >
+                  {bulkDeleteLoading ? '삭제 중...' : `${selectedIds.size}개 삭제`}
+                </button>
+                <button
+                  onClick={() => { setSelectMode(false); setSelectedIds(new Set()); }}
+                  className="px-4 py-2.5 border border-slate-200 text-slate-600 rounded-xl font-semibold text-sm hover:bg-slate-50 transition-colors"
+                >
+                  취소
+                </button>
+              </>
+            ) : (
+              <>
+                {projects.length > 0 && (
+                  <button
+                    onClick={() => setSelectMode(true)}
+                    className="px-4 py-2.5 border border-slate-200 text-slate-600 rounded-xl font-semibold text-sm hover:bg-slate-50 transition-colors"
+                  >
+                    선택
+                  </button>
+                )}
+                <button
+                  onClick={() => navigate('/upload')}
+                  className="flex items-center gap-2 px-4 py-2.5 bg-emerald-600 text-white rounded-xl font-semibold text-sm hover:bg-emerald-700 transition-colors"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                  새 영상 업로드
+                </button>
+              </>
+            )}
+          </div>
         </div>
 
         {/* 로딩 */}
@@ -275,10 +344,17 @@ export function DashboardPage() {
               const videoSrc = isYoutube ? (project.sourceUrl ?? '') : (project.fileUrl ?? '');
               const cardColor = CARD_COLORS[idx % CARD_COLORS.length];
 
+              const isSelected = pid ? selectedIds.has(pid) : false;
+
               return (
                 <div
                   key={pid ?? idx}
                   onClick={() => {
+                    if (!pid) return;
+                    if (selectMode) {
+                      toggleSelect(pid);
+                      return;
+                    }
                     if (menuOpenId !== null) return;
                     if (project.status === 'CREATED' || project.status === 'PROCESSING') {
                       showProcessingToast();
@@ -291,10 +367,14 @@ export function DashboardPage() {
                       navigate(`/translate/${pid}`);
                     }
                   }}
-                  className={`bg-white rounded-2xl border border-gray-200 transition-all group ${
-                    project.status === 'CREATED' || project.status === 'PROCESSING'
-                      ? 'cursor-not-allowed opacity-75'
-                      : 'hover:shadow-md hover:border-emerald-300 cursor-pointer'
+                  className={`bg-white rounded-2xl border transition-all group ${
+                    selectMode
+                      ? isSelected
+                        ? 'border-emerald-400 ring-2 ring-emerald-200 cursor-pointer'
+                        : 'border-gray-200 cursor-pointer hover:border-emerald-200'
+                      : project.status === 'CREATED' || project.status === 'PROCESSING'
+                        ? 'border-gray-200 cursor-not-allowed opacity-75'
+                        : 'border-gray-200 hover:shadow-md hover:border-emerald-300 cursor-pointer'
                   }`}
                 >
                   {/* 썸네일 */}
@@ -355,6 +435,19 @@ export function DashboardPage() {
                     <span className={`absolute top-2.5 right-2.5 text-xs font-semibold px-2.5 py-1 rounded-full backdrop-blur-sm ${statusCfg.color}`}>
                       {statusCfg.label}
                     </span>
+
+                    {/* 체크박스 (선택 모드) */}
+                    {selectMode && (
+                      <div className={`absolute top-2.5 left-2.5 h-6 w-6 rounded-full border-2 flex items-center justify-center transition-colors ${
+                        isSelected ? 'bg-emerald-500 border-emerald-500' : 'bg-white/80 border-slate-300'
+                      }`}>
+                        {isSelected && (
+                          <svg className="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                          </svg>
+                        )}
+                      </div>
+                    )}
                   </div>
 
                   {/* 카드 정보 */}
@@ -362,8 +455,8 @@ export function DashboardPage() {
                     <div className="flex items-start justify-between gap-2 mb-2">
                       <h3 className="font-semibold text-slate-800 text-sm truncate flex-1">{project.title}</h3>
 
-                      {/* ⋮ 메뉴 버튼 */}
-                      {pid && (
+                      {/* ⋮ 메뉴 버튼 (선택 모드에서 숨김) */}
+                      {pid && !selectMode && (
                         <div className="relative shrink-0" ref={menuOpenId === pid ? menuRef : undefined}>
                           <button
                             onClick={e => {

--- a/frontend/src/app/pages/StudyPage.tsx
+++ b/frontend/src/app/pages/StudyPage.tsx
@@ -1,13 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getMySavedWords, deleteSavedWord, explainWord } from '@/api/words';
-import type { SavedWordResult } from '@/api/words';
+import { getMySavedWords, deleteSavedWord, explainWord, generateWordExamples } from '@/api/words';
+import type { SavedWordResult, ExampleItem } from '@/api/words';
 import { useAuth } from '@/app/providers/AuthProvider';
 
-interface ExampleSentence {
-  en: string;
-  ko: string;
-}
+// API ExampleItem을 그대로 사용 (sentence, translatedSentence)
+type ExampleSentence = ExampleItem;
 
 // API 응답을 화면용으로 래핑하는 타입
 type SavedWord = SavedWordResult & { lang?: string };
@@ -28,16 +26,16 @@ const ANT_POOLS = [
 ];
 const EXAMPLE_FMTS = [
   (w: string) => ({
-    en: `We need to practice "${w}" in real conversations.`,
-    ko: `실제 대화에서 "${w}"을(를) 연습해 보아야 한다.`,
+    sentence: `We need to practice "${w}" in real conversations.`,
+    translatedSentence: `실제 대화에서 "${w}"을(를) 연습해 보아야 한다.`,
   }),
   (w: string) => ({
-    en: `Understanding "${w}" is essential for language learners.`,
-    ko: `"${w}"의 의미를 이해하는 것은 언어 학습자에게 필수적이다.`,
+    sentence: `Understanding "${w}" is essential for language learners.`,
+    translatedSentence: `"${w}"의 의미를 이해하는 것은 언어 학습자에게 필수적이다.`,
   }),
   (w: string) => ({
-    en: `The speaker used "${w}" to make the sentence more natural.`,
-    ko: `화자는 문장을 더 자연스럽게 만들기 위해 "${w}"을(를) 사용했다.`,
+    sentence: `The speaker used "${w}" to make the sentence more natural.`,
+    translatedSentence: `화자는 문장을 더 자연스럽게 만들기 위해 "${w}"을(를) 사용했다.`,
   }),
 ];
 
@@ -128,7 +126,7 @@ function WordNetworkSVG({ word, relatedWords }: {
       })}
 
       {/* 관련 단어 레이블 */}
-      <text x="170" y="14" textAnchor="middle" fontSize="8" fill="#6366f1" fontWeight="700" letterSpacing="0.5">관련 단어</text>
+      <text x="170" y="14" textAnchor="middle" fontSize="8" fill="#6366f1" fontWeight="700" letterSpacing="0.5">유의어</text>
     </svg>
   );
 }
@@ -143,6 +141,7 @@ export function StudyPage() {
   const [search, setSearch] = useState('');
   const [view, setView] = useState<'list' | 'card'>('list');
   const [flipped, setFlipped] = useState<number | null>(null);
+  const [cardIndex, setCardIndex] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   // 관련 단어 분석 상태 (key: savedWordId)
@@ -199,26 +198,40 @@ export function StudyPage() {
     }
   };
 
-  const handleGenerateExamples = (word: SavedWord) => {
+  const handleGenerateExamples = async (word: SavedWord) => {
     setExamplesMap(prev => ({ ...prev, [word.savedWordId]: 'loading' }));
-    setTimeout(() => {
+    try {
+      const result = await generateWordExamples(word.savedWordId);
+      setExamplesMap(prev => ({ ...prev, [word.savedWordId]: result.examples }));
+    } catch (err) {
+      console.error('[OverLang] 예문 생성 실패:', err);
+      // 실패 시 목 데이터로 폴백
       setExamplesMap(prev => ({ ...prev, [word.savedWordId]: getMockExamples(word.word) }));
-    }, 1800);
+    }
   };
 
   const handleTTS = (text: string, lang?: string) => {
-    // lang 명시 없으면 텍스트 내용으로 자동 감지
     const resolvedLang = lang ?? detectLang(text);
+    const langPrefix = resolvedLang.split('-')[0]; // 'ja', 'ko', 'en' ...
+
     window.speechSynthesis.cancel();
-    // cancel()은 비동기로 처리되므로 speak()를 즉시 호출하면 씹힘 → 100ms 딜레이
     setTimeout(() => {
       const utter = new SpeechSynthesisUtterance(text);
       utter.lang = resolvedLang;
       utter.rate = 0.9;
-      // paused 상태면 resume 후 speak
-      if (window.speechSynthesis.paused) {
-        window.speechSynthesis.resume();
-      }
+
+      // 최적 음성 선택 (Google 클라우드 음성 > Enhanced/Premium > 기타 순)
+      const voices = window.speechSynthesis.getVoices();
+      const langVoices = voices.filter(v => v.lang.startsWith(langPrefix));
+      const googleVoice   = langVoices.find(v => v.name.toLowerCase().includes('google'));
+      const enhancedVoice = langVoices.find(v =>
+        v.name.toLowerCase().includes('enhanced') ||
+        v.name.toLowerCase().includes('premium')
+      );
+      const bestVoice = googleVoice ?? enhancedVoice ?? langVoices[0] ?? null;
+      if (bestVoice) utter.voice = bestVoice;
+
+      if (window.speechSynthesis.paused) window.speechSynthesis.resume();
       window.speechSynthesis.speak(utter);
     }, 100);
   };
@@ -229,13 +242,6 @@ export function StudyPage() {
     w.translatedSentence?.includes(search) ||
     w.meaning?.includes(search)
   );
-
-  const thisWeekCount = words.filter(w => {
-    try {
-      const d = new Date(w.createdAt);
-      return (Date.now() - d.getTime()) / 86400000 <= 7;
-    } catch { return false; }
-  }).length;
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -299,23 +305,6 @@ export function StudyPage() {
       </header>
 
       <div className="mx-auto max-w-3xl px-6 py-6 space-y-4">
-
-        {/* 통계 */}
-        <div className="grid grid-cols-3 gap-3">
-          {[
-            { label: '전체',    value: words.length,  dot: 'bg-slate-400',  card: 'bg-white border border-slate-200 text-slate-800' },
-            { label: '이번 주', value: thisWeekCount,  dot: 'bg-orange-400', card: 'bg-orange-50 border border-orange-100 text-orange-700' },
-            { label: '숙지 완료', value: 0,            dot: 'bg-emerald-400', card: 'bg-emerald-50 border border-emerald-100 text-emerald-700' },
-          ].map(s => (
-            <div key={s.label} className={`rounded-2xl shadow-sm px-4 py-3.5 text-center ${s.card}`}>
-              <p className="text-2xl font-extrabold">{s.value}</p>
-              <div className="flex items-center justify-center gap-1.5 mt-1">
-                <div className={`h-1.5 w-1.5 rounded-full ${s.dot}`} />
-                <p className="text-xs opacity-70">{s.label}</p>
-              </div>
-            </div>
-          ))}
-        </div>
 
         {/* 검색 */}
         <div className="relative">
@@ -471,7 +460,7 @@ export function StudyPage() {
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                             d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                         </svg>
-                        관련 단어
+                        유의어
                         {relations && relations !== 'loading' && (
                           <span className="ml-0.5 h-1.5 w-1.5 rounded-full bg-orange-400 inline-block" />
                         )}
@@ -516,7 +505,7 @@ export function StudyPage() {
                       {/* 단어망 */}
                       <div>
                         <div className="flex items-center justify-between mb-3">
-                          <p className="text-xs font-bold text-slate-700 uppercase tracking-wider">관련 단어</p>
+                          <p className="text-xs font-bold text-slate-700 uppercase tracking-wider">유의어</p>
                         </div>
 
                         {!relations ? (
@@ -528,7 +517,7 @@ export function StudyPage() {
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                 d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                             </svg>
-                            관련 단어 분석하기
+                            유의어 분석하기
                           </button>
                         ) : relations === 'loading' ? (
                           <div className="flex flex-col items-center justify-center py-10 gap-3">
@@ -557,9 +546,6 @@ export function StudyPage() {
                         <div className="flex items-center justify-between mb-3">
                           <div className="flex items-center gap-2">
                             <p className="text-xs font-bold text-slate-700 uppercase tracking-wider">AI 예문</p>
-                            <span className="text-[10px] px-2 py-0.5 rounded-full bg-violet-50 text-violet-500 font-medium border border-violet-100">
-                              AI 생성 예정
-                            </span>
                           </div>
                         </div>
 
@@ -585,7 +571,7 @@ export function StudyPage() {
                                 <div className="flex items-center gap-2">
                                   <span className="text-[10px] font-bold text-violet-500 uppercase tracking-wider">예문 {i + 1}</span>
                                   <button
-                                    onClick={() => handleTTS(ex.en, word.lang ?? 'en-US')}
+                                    onClick={e => { e.stopPropagation(); handleTTS(ex.sentence); }}
                                     className="flex h-5 w-5 items-center justify-center rounded-full bg-violet-100 hover:bg-violet-200 text-violet-500 transition-colors"
                                   >
                                     <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
@@ -593,11 +579,10 @@ export function StudyPage() {
                                     </svg>
                                   </button>
                                 </div>
-                                <p className="text-sm text-slate-700 font-medium leading-relaxed">{ex.en}</p>
-                                <p className="text-xs text-slate-400 leading-relaxed">{ex.ko}</p>
+                                <p className="text-sm text-slate-700 font-medium leading-relaxed">{ex.sentence}</p>
+                                <p className="text-xs text-slate-400 leading-relaxed">{ex.translatedSentence}</p>
                               </div>
                             ))}
-                            <p className="text-center text-[10px] text-slate-300">* 예시 데이터 · 실제 AI 생성 기능 개발 중</p>
                           </div>
                         )}
                       </div>
@@ -610,51 +595,127 @@ export function StudyPage() {
         )}
 
         {/* ── 플래시카드 뷰 ── */}
-        {!wordsLoading && view === 'card' && filtered.length > 0 && (
-          <div className="space-y-4">
-            <p className="text-xs text-center text-slate-400">카드를 클릭하면 뒤집어집니다</p>
-            {filtered.map((word, i) => (
+        {!wordsLoading && view === 'card' && filtered.length > 0 && (() => {
+          const safeIndex = Math.min(cardIndex, filtered.length - 1);
+          const word = filtered[safeIndex];
+          const isFlipped = flipped === safeIndex;
+
+          return (
+            <div className="flex flex-col items-center gap-5">
+
+              {/* 진행 표시 */}
+              <div className="flex items-center gap-3 w-full">
+                <button
+                  onClick={() => { setCardIndex(i => Math.max(0, i - 1)); setFlipped(null); }}
+                  disabled={safeIndex === 0}
+                  className="flex h-8 w-8 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-400 hover:text-slate-700 disabled:opacity-25 transition-all shadow-sm shrink-0"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+                <div className="flex-1 text-center">
+                  <p className="text-xs font-semibold text-slate-500 mb-1.5">{safeIndex + 1} / {filtered.length}</p>
+                  <div className="w-full bg-slate-100 rounded-full h-1">
+                    <div
+                      className="bg-orange-400 h-1 rounded-full transition-all duration-300"
+                      style={{ width: `${((safeIndex + 1) / filtered.length) * 100}%` }}
+                    />
+                  </div>
+                </div>
+                <button
+                  onClick={() => { setCardIndex(i => Math.min(filtered.length - 1, i + 1)); setFlipped(null); }}
+                  disabled={safeIndex === filtered.length - 1}
+                  className="flex h-8 w-8 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-400 hover:text-slate-700 disabled:opacity-25 transition-all shadow-sm shrink-0"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </div>
+
+              {/* 카드 (3D 플립) */}
               <div
-                key={word.savedWordId}
-                onClick={() => setFlipped(flipped === i ? null : i)}
-                className="cursor-pointer select-none"
+                className="w-full cursor-pointer select-none"
+                style={{ perspective: '1200px' }}
+                onClick={() => setFlipped(isFlipped ? null : safeIndex)}
               >
-                <div className={`rounded-2xl border-2 transition-all duration-300 ${
-                  flipped === i
-                    ? 'bg-gradient-to-br from-orange-400 to-amber-400 border-orange-300 shadow-xl shadow-orange-100/60'
-                    : 'bg-white border-slate-200 hover:border-orange-200 shadow-sm hover:shadow-lg'
-                }`}>
-                  {flipped === i ? (
-                    <div className="p-9 text-center">
-                      {word.meaning && (
-                        <p className="text-sm font-semibold text-white/90 mb-4 leading-relaxed">{word.meaning}</p>
-                      )}
-                      <p className="text-[10px] font-bold text-orange-100 mb-3 uppercase tracking-widest">원문 문장</p>
-                      <p className="text-sm font-medium text-white leading-relaxed">{word.originalSentence}</p>
-                      {word.translatedSentence && (
-                        <p className="text-xs text-orange-100/80 mt-3 leading-relaxed">{word.translatedSentence}</p>
-                      )}
-                      <div className="mt-5 pt-4 border-t border-white/20">
-                        <p className="text-xs text-orange-100/70">{new Date(word.createdAt).toLocaleDateString('ko-KR')}</p>
+                <div
+                  style={{
+                    position: 'relative',
+                    height: '340px',
+                    transformStyle: 'preserve-3d',
+                    transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+                    transition: 'transform 0.55s cubic-bezier(0.4, 0, 0.2, 1)',
+                  }}
+                >
+                  {/* 앞면 */}
+                  <div
+                    style={{ backfaceVisibility: 'hidden', WebkitBackfaceVisibility: 'hidden' }}
+                    className="absolute inset-0 flex flex-col items-center justify-center rounded-3xl bg-white border border-slate-200 shadow-lg p-8 text-center"
+                  >
+                    {word.lang && (
+                      <span className="text-[10px] font-bold px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-400 uppercase tracking-wide mb-3">
+                        {word.lang.split('-')[0]}
+                      </span>
+                    )}
+                    <p className="text-4xl font-extrabold text-slate-800 tracking-tight mb-4">{word.word}</p>
+                    {word.contextMeaning && (
+                      <p className="text-sm text-slate-400 italic mb-4 max-w-xs leading-relaxed">"{word.contextMeaning}"</p>
+                    )}
+                    <button
+                      onClick={e => { e.stopPropagation(); handleTTS(word.word, word.lang); }}
+                      className="flex h-9 w-9 items-center justify-center rounded-full bg-violet-50 hover:bg-violet-100 text-violet-400 hover:text-violet-600 transition-colors mt-1"
+                    >
+                      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
+                      </svg>
+                    </button>
+                    <p className="text-xs text-slate-300 mt-8">탭하여 뜻 확인 →</p>
+                  </div>
+
+                  {/* 뒷면 */}
+                  <div
+                    style={{
+                      backfaceVisibility: 'hidden',
+                      WebkitBackfaceVisibility: 'hidden',
+                      transform: 'rotateY(180deg)',
+                    }}
+                    className="absolute inset-0 flex flex-col justify-center rounded-3xl bg-gradient-to-br from-orange-400 to-amber-400 shadow-xl p-8"
+                  >
+                    {word.meaning && (
+                      <p className="text-lg font-bold text-white text-center leading-snug mb-5">{word.meaning}</p>
+                    )}
+                    {word.originalSentence && (
+                      <div className="bg-white/20 backdrop-blur-sm rounded-2xl px-4 py-3.5">
+                        <p className="text-sm font-medium text-white leading-relaxed">{word.originalSentence}</p>
+                        {word.translatedSentence && (
+                          <p className="text-xs text-orange-100/80 mt-2 leading-relaxed">{word.translatedSentence}</p>
+                        )}
                       </div>
-                    </div>
-                  ) : (
-                    <div className="p-9 text-center">
-                      <p className="text-[10px] font-bold text-slate-400 mb-3 uppercase tracking-widest">단어 / 표현</p>
-                      <p className="text-3xl font-extrabold text-slate-800 tracking-tight">{word.word}</p>
-                      {word.lang && (
-                        <span className="inline-block mt-2 text-[10px] font-semibold px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-400 uppercase">
-                          {word.lang.split('-')[0]}
-                        </span>
+                    )}
+                    <div className="flex items-center justify-between mt-5">
+                      <button
+                        onClick={e => { e.stopPropagation(); handleTTS(word.originalSentence ?? word.word); }}
+                        className="flex h-8 w-8 items-center justify-center rounded-full bg-white/20 hover:bg-white/30 text-white transition-colors"
+                      >
+                        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
+                        </svg>
+                      </button>
+                      {word.projectTitle && (
+                        <p className="text-xs text-orange-100/70 truncate max-w-[160px]">{word.projectTitle}</p>
                       )}
-                      <p className="text-xs text-slate-300 mt-5">탭하여 문장 맥락 확인</p>
+                      <p className="text-xs text-orange-100/60 shrink-0">{new Date(word.createdAt).toLocaleDateString('ko-KR')}</p>
                     </div>
-                  )}
+                  </div>
                 </div>
               </div>
-            ))}
-          </div>
-        )}
+
+              <p className="text-xs text-slate-400">카드를 탭해서 뒤집어보세요</p>
+            </div>
+          );
+        })()}
 
       </div>
     </div>

--- a/frontend/src/app/pages/TranslatePage.tsx
+++ b/frontend/src/app/pages/TranslatePage.tsx
@@ -1052,9 +1052,9 @@ export function TranslatePage() {
 
           {/* ── ① 영상 요약 ── */}
           {activeTab === '요약' && (
-            <div className="flex-1 overflow-y-auto px-4 py-4">
+            <div className="flex-1 overflow-y-auto">
               {!learningContents ? (
-                <div className="flex flex-col items-center justify-center h-full gap-3 text-center">
+                <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-4">
                   <div className="flex h-14 w-14 items-center justify-center rounded-full bg-violet-100">
                     <svg className="h-7 w-7 text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -1063,22 +1063,45 @@ export function TranslatePage() {
                   <p className="text-sm text-slate-500 font-medium">학습 콘텐츠가 없습니다</p>
                   <p className="text-xs text-slate-400">AI 분석이 완료된 영상에서 확인할 수 있어요</p>
                 </div>
+              ) : !learningContents.summary ? (
+                <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-4">
+                  <p className="text-sm text-slate-400">요약 데이터가 없습니다</p>
+                </div>
               ) : (
-                <div className="space-y-4">
-                  {learningContents.summary && (
-                    <div className="rounded-xl bg-violet-50 border border-violet-100 p-4">
-                      <p className="text-xs font-bold text-violet-500 mb-2 flex items-center gap-1.5">
-                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                <div>
+                  {/* 헤더 배너 */}
+                  <div className="bg-gradient-to-br from-violet-500 to-purple-600 px-5 pt-5 pb-6">
+                    <div className="flex items-center gap-2 mb-3">
+                      <span className="text-[10px] font-bold tracking-widest text-violet-200 uppercase">AI Summary</span>
+                      <span className="flex items-center gap-1 text-[10px] text-violet-300 bg-white/10 rounded-full px-2 py-0.5">
+                        <svg className="h-2.5 w-2.5" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/>
                         </svg>
-                        영상 요약
-                      </p>
-                      <p className="text-sm text-slate-700 leading-relaxed">{learningContents.summary.content}</p>
+                        영상 기반 요약
+                      </span>
                     </div>
-                  )}
-                  {!learningContents.summary && (
-                    <p className="text-sm text-slate-400 text-center py-8">요약 데이터가 없습니다</p>
-                  )}
+                    <p className="text-white font-bold text-base leading-snug">영상 핵심 내용 요약</p>
+                    <p className="text-violet-200 text-xs mt-1">
+                      {learningContents.summary.content.length}자 · 약 {Math.ceil(learningContents.summary.content.length / 200)}분 읽기
+                    </p>
+                  </div>
+
+                  {/* 요약 본문 */}
+                  <div className="px-5 py-5">
+                    <div className="space-y-3">
+                      {learningContents.summary.content.split(/\n+/).filter(Boolean).map((para, i) => (
+                        <p key={i} className="text-sm text-slate-700 leading-relaxed">{para}</p>
+                      ))}
+                    </div>
+
+                    {/* 하단 뱃지 */}
+                    <div className="mt-6 pt-4 border-t border-slate-100 flex items-center gap-2">
+                      <svg className="h-3.5 w-3.5 text-violet-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                      <p className="text-[11px] text-slate-400">AI가 영상 자막을 분석하여 자동 생성한 요약입니다</p>
+                    </div>
+                  </div>
                 </div>
               )}
             </div>
@@ -1196,28 +1219,6 @@ export function TranslatePage() {
                             </svg>
                             {repeatRange?.startSec === sub.startSec ? '반복 중' : '구간 반복'}
                           </button>
-                          <button onClick={e => { e.stopPropagation(); handleSentenceAnalysis(sub); }} className="flex items-center gap-1.5 text-xs font-medium text-emerald-500 hover:text-emerald-700 transition-colors">
-                            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                            </svg>
-                            원문 분석
-                          </button>
-                          {sub.translation && (
-                            <button
-                              onClick={e => {
-                                e.stopPropagation();
-                                setSentenceData({ sentence: sub.translation, parts: getMockSentenceParts(sub.translation), grammar: getMockGrammar(sub.translation) });
-                                setRightPanel('sentence');
-                                setActiveTab('자막');
-                              }}
-                              className="flex items-center gap-1.5 text-xs font-medium text-emerald-500 hover:text-emerald-700 transition-colors"
-                            >
-                              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                              </svg>
-                              번역 분석
-                            </button>
-                          )}
                         </div>
                       </div>
                     );
@@ -1351,9 +1352,9 @@ export function TranslatePage() {
 
           {/* ── ③ 빈출 단어 ── */}
           {activeTab === '빈출단어' && (
-            <div className="flex-1 overflow-y-auto px-4 py-4">
+            <div className="flex-1 overflow-y-auto">
               {!learningContents || learningContents.keywords.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full gap-3 text-center">
+                <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-4">
                   <div className="flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100">
                     <svg className="h-7 w-7 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
@@ -1363,32 +1364,67 @@ export function TranslatePage() {
                   <p className="text-xs text-slate-400">AI 분석이 완료된 영상에서 확인할 수 있어요</p>
                 </div>
               ) : (
-                <div className="space-y-2">
-                  {learningContents.keywords.map(kw => (
-                    <div
-                      key={kw.learningContentId}
-                      className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 cursor-pointer hover:border-emerald-300 hover:bg-emerald-50/30 transition-colors"
-                      onClick={() => {
-                        if (kw.startTime != null) {
-                          if (videoRef.current) { videoRef.current.currentTime = kw.startTime; videoRef.current.play(); }
-                          else if (ytPlayerRef.current) { ytPlayerRef.current.seekTo(kw.startTime, true); }
-                        }
-                      }}
-                    >
-                      <span className="mt-0.5 shrink-0 text-base">{kw.title}</span>
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm text-slate-700 leading-relaxed">{kw.content}</p>
-                        {kw.startTime != null && (
-                          <p className="text-[10px] text-slate-400 mt-1 font-mono flex items-center gap-1">
-                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            {secToTimecode(kw.startTime)}
-                          </p>
-                        )}
-                      </div>
+                <div>
+                  {/* 헤더 */}
+                  <div className="px-4 pt-4 pb-3 flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-bold text-slate-700">핵심 단어 · 표현</p>
+                      <p className="text-[11px] text-slate-400 mt-0.5">{learningContents.keywords.length}개 · 클릭하면 해당 구간으로 이동</p>
                     </div>
-                  ))}
+                    <span className="flex items-center gap-1 text-[10px] font-semibold text-emerald-600 bg-emerald-50 border border-emerald-100 rounded-full px-2.5 py-1">
+                      <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                      AI 분석
+                    </span>
+                  </div>
+
+                  <div className="px-3 pb-4 space-y-2">
+                    {learningContents.keywords.map((kw, idx) => {
+                      const rankColors = [
+                        'from-amber-400 to-yellow-400 text-white',   // 1위
+                        'from-slate-400 to-slate-300 text-white',    // 2위
+                        'from-orange-400 to-amber-500 text-white',   // 3위
+                      ];
+                      const rankBg = idx < 3 ? rankColors[idx] : null;
+                      return (
+                        <div
+                          key={kw.learningContentId}
+                          className="rounded-2xl border border-slate-200 bg-white overflow-hidden cursor-pointer hover:border-emerald-300 hover:shadow-md transition-all group"
+                          onClick={() => {
+                            if (kw.startTime != null) {
+                              if (videoRef.current) { videoRef.current.currentTime = kw.startTime; videoRef.current.play(); }
+                              else if (ytPlayerRef.current) { ytPlayerRef.current.seekTo(kw.startTime, true); }
+                            }
+                          }}
+                        >
+                          <div className="flex items-stretch">
+                            {/* 왼쪽 순위 바 */}
+                            <div className={`flex flex-col items-center justify-center w-10 shrink-0 ${rankBg ? `bg-gradient-to-b ${rankBg}` : 'bg-slate-50'}`}>
+                              <span className={`text-xs font-extrabold ${rankBg ? '' : 'text-slate-400'}`}>
+                                {idx + 1}
+                              </span>
+                            </div>
+                            {/* 본문 */}
+                            <div className="flex-1 min-w-0 px-3 py-3">
+                              <p className="text-sm font-bold text-slate-800 leading-snug mb-1">{kw.title}</p>
+                              <p className="text-xs text-slate-500 leading-relaxed">{kw.content}</p>
+                            </div>
+                            {/* 타임스탬프 */}
+                            {kw.startTime != null && (
+                              <div className="flex flex-col items-center justify-center px-3 shrink-0 border-l border-slate-100 group-hover:border-emerald-100 group-hover:bg-emerald-50/50 transition-colors">
+                                <svg className="h-3.5 w-3.5 text-emerald-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                <span className="text-[10px] font-mono text-slate-400 whitespace-nowrap">{secToTimecode(kw.startTime)}</span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## 작업 개요
프로젝트 다중 선택 삭제 / 예문 생성
## 관련 이슈
- close #142

## 작업 내용
- DashboardPage: 프로젝트 다중 선택 삭제 기능 추가
- TranslatePage: 원문 분석/번역 분석 버튼 제거, 영상 요약/빈출 단어 디자인 개선
- StudyPage: 플래시카드 3D 플립 + 한 장씩 보기로 개편, 통계 카드 제거, TTS 음성 품질 개선
- words.ts: generateWordExamples API 함수 추가
## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 15 48" src="https://github.com/user-attachments/assets/298b7e35-5c6d-41c4-847e-017e7f74bd97" />
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 16 06" src="https://github.com/user-attachments/assets/498f44d8-bec3-400f-a76a-48bd9334facf" />
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 16 33" src="https://github.com/user-attachments/assets/baa935f0-6cb4-46df-a3ac-553c15a9b0c1" />
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 16 39" src="https://github.com/user-attachments/assets/ba39d472-a53d-4259-abf2-7a404989df89" />
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 17 04" src="https://github.com/user-attachments/assets/be052cbf-4cf3-4004-8175-3f999baee434" />
<img width="1914" height="886" alt="스크린샷 2026-05-24 오후 10 17 13" src="https://github.com/user-attachments/assets/c41f3f20-7474-4e1d-b139-c9c41706e9c6" />

## 기타 사항

