### PR TITLE
feat: 회원 탈퇴 API 연동, 비밀번호 찾기 기능, 일본어 중국어 언어 감지 수정

### DIFF
--- a/frontend/src/app/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/app/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/app/providers/AuthProvider';
+
+export function ForgotPasswordPage() {
+  const navigate = useNavigate();
+  const { sendPasswordReset } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      await sendPasswordReset(email);
+      setSent(true);
+    } catch (err: any) {
+      const code = err?.code ?? '';
+      if (code === 'auth/user-not-found' || code === 'auth/invalid-email') {
+        setError('등록되지 않은 이메일이거나 형식이 올바르지 않습니다.');
+      } else {
+        setError('이메일 전송에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex">
+
+      {/* ── 왼쪽 브랜딩 패널 ── */}
+      <div className="hidden lg:flex lg:w-1/2 flex-col justify-between bg-gradient-to-br from-emerald-600 to-teal-500 p-12 text-white">
+        <div className="flex items-center gap-3 cursor-pointer" onClick={() => navigate('/')}>
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-white/20 backdrop-blur-sm">
+            <svg className="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.069A1 1 0 0121 8.87v6.26a1 1 0 01-1.447.894L15 14M3 8a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+            </svg>
+          </div>
+          <span className="text-xl font-bold">OverLang</span>
+        </div>
+        <div>
+          <h2 className="text-4xl font-extrabold leading-tight mb-4">
+            비밀번호를<br />재설정해드릴게요
+          </h2>
+          <p className="text-emerald-100 text-lg leading-relaxed">
+            가입한 이메일 주소를 입력하면<br />재설정 링크를 보내드립니다.
+          </p>
+        </div>
+        <p className="text-emerald-200 text-sm">© 2026 OverLang. All rights reserved.</p>
+      </div>
+
+      {/* ── 오른쪽 폼 ── */}
+      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6 py-12">
+        <div className="w-full max-w-md">
+
+          {/* 모바일 로고 */}
+          <div className="flex items-center gap-2 mb-8 lg:hidden">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-600">
+              <svg className="h-4 w-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.069A1 1 0 0121 8.87v6.26a1 1 0 01-1.447.894L15 14M3 8a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+              </svg>
+            </div>
+            <span className="font-bold text-slate-800">OverLang</span>
+          </div>
+
+          {sent ? (
+            /* ── 전송 완료 ── */
+            <div className="text-center">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 mx-auto mb-5">
+                <svg className="h-8 w-8 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <h1 className="text-2xl font-extrabold text-slate-900 mb-2">이메일을 확인해주세요</h1>
+              <p className="text-slate-500 text-sm leading-relaxed mb-2">
+                <span className="font-semibold text-slate-700">{email}</span>으로<br />
+                비밀번호 재설정 링크를 보내드렸어요.
+              </p>
+              <p className="text-xs text-slate-400 mb-8">스팸 폴더도 확인해보세요</p>
+              <button
+                onClick={() => navigate('/login')}
+                className="w-full rounded-xl bg-emerald-600 px-4 py-3.5 font-semibold text-white hover:bg-emerald-500 transition-all shadow-lg shadow-emerald-100"
+              >
+                로그인으로 돌아가기
+              </button>
+            </div>
+          ) : (
+            /* ── 이메일 입력 폼 ── */
+            <>
+              <button
+                onClick={() => navigate('/login')}
+                className="flex items-center gap-1.5 text-sm text-slate-400 hover:text-slate-600 transition-colors mb-6"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+                로그인으로 돌아가기
+              </button>
+
+              <h1 className="text-3xl font-extrabold text-slate-900 mb-1">비밀번호 찾기</h1>
+              <p className="text-slate-500 mb-8">가입한 이메일로 재설정 링크를 보내드려요</p>
+
+              {error && (
+                <div className="mb-5 flex items-center gap-2 rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600">
+                  <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  {error}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">가입한 이메일</label>
+                  <input
+                    type="email"
+                    placeholder="your@email.com"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    required
+                    autoFocus
+                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-800 placeholder-slate-400 focus:bg-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100 transition-all"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="w-full rounded-xl bg-emerald-600 px-4 py-3.5 font-semibold text-white hover:bg-emerald-500 transition-all shadow-lg shadow-emerald-100 hover:shadow-emerald-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {submitting ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      전송 중...
+                    </span>
+                  ) : '재설정 링크 보내기'}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/pages/LoginPage.tsx
+++ b/frontend/src/app/pages/LoginPage.tsx
@@ -141,6 +141,13 @@ export function LoginPage() {
             <div>
               <div className="flex items-center justify-between mb-1.5">
                 <label className="text-sm font-medium text-slate-700">비밀번호</label>
+                <button
+                  type="button"
+                  onClick={() => navigate('/forgot-password')}
+                  className="text-xs text-emerald-600 hover:text-emerald-500 transition-colors"
+                >
+                  비밀번호 찾기
+                </button>
               </div>
               <input
                 type="password"

--- a/frontend/src/app/pages/ProcessingPage.tsx
+++ b/frontend/src/app/pages/ProcessingPage.tsx
@@ -49,6 +49,7 @@ export function ProcessingPage() {
   const [retrying, setRetrying] = useState(false);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastValidStageIndex = useRef(0);
 
   const handleRetry = async () => {
     if (!projectId) return;
@@ -111,7 +112,15 @@ export function ProcessingPage() {
     return stopPolling;
   }, [authLoading, user, jobId]);
 
-  const stageIndex = STAGES.findIndex(s => s.key === currentStage);
+  const stageIndex = (() => {
+    const idx = STAGES.findIndex(s => s.key === currentStage);
+    if (idx !== -1) {
+      lastValidStageIndex.current = idx;
+      return idx;
+    }
+    // 백엔드가 모르는 중간 단계를 잠깐 보낼 때 마지막 유효 단계 유지
+    return lastValidStageIndex.current;
+  })();
   const isFailed = status === 'FAILED';
   const isCompleted = status === 'COMPLETED';
 

--- a/frontend/src/app/pages/StudyPage.tsx
+++ b/frontend/src/app/pages/StudyPage.tsx
@@ -188,7 +188,7 @@ export function StudyPage() {
         selectedTextType: word.selectedTextType ?? 'ORIGINAL',
         originalSentence: word.originalSentence ?? '',
         translatedSentence: word.translatedSentence ?? '',
-        sourceLanguage: word.lang ? word.lang.split('-')[0].toUpperCase() : 'EN',
+        sourceLanguage: (word.lang ?? detectLang(word.word)).split('-')[0].toUpperCase(),
         targetLanguage: 'KO',
       });
       setRelationsMap(prev => ({ ...prev, [word.savedWordId]: result.relatedWords }));

--- a/frontend/src/app/pages/TranslatePage.tsx
+++ b/frontend/src/app/pages/TranslatePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
-import { getVideoPresignedUrl, getProjectJobs, getSegments, getOcrItems, updateTranslation, getLearningContents } from '@/api/video';
+import { getVideoPresignedUrl, getProjectJobs, getSegments, getOcrItems, updateTranslation, getLearningContents, retryJob } from '@/api/video';
 import type { SegmentResult, OcrItemResult, SegmentWord, LearningContentsResult } from '@/api/video';
 import { explainWord, saveWord, getMySavedWords } from '@/api/words';
 import { useAuth } from '@/app/providers/AuthProvider';
@@ -291,6 +291,7 @@ export function TranslatePage() {
 
   // 저장 토스트
   const [saveToast, setSaveToast] = useState(false);
+  const [retrying, setRetrying] = useState(false);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [showOcr, setShowOcr] = useState(true);
@@ -498,6 +499,22 @@ export function TranslatePage() {
   };
 
   // 저장 핸들러
+  const handleRetry = async () => {
+    if (!projectId || retrying) return;
+    if (!window.confirm('영상을 다시 분석합니다. 계속할까요?')) return;
+    setRetrying(true);
+    try {
+      const result = await retryJob(projectId);
+      navigate('/processing', {
+        state: { jobId: result.jobId, projectId, videoSrc, targetLanguage },
+      });
+    } catch {
+      alert('재처리 요청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setRetrying(false);
+    }
+  };
+
   const handleSaveSubtitles = async () => {
     // projectId 없으면 localStorage 저장 (demo 모드)
     if (!projectId) {
@@ -1173,19 +1190,32 @@ export function TranslatePage() {
                           className="w-full text-xs border border-slate-100 rounded-lg px-2 py-1.5 mb-2 leading-relaxed text-slate-500 bg-slate-50 flex flex-wrap"
                         >
                           {sub.original ? (
-                            sub.original.split(/(\s+)/).map((token, i) => {
-                              const isSpace = /^\s+$/.test(token);
-                              if (isSpace) return <span key={i}>&nbsp;</span>;
-                              return (
-                                <span
-                                  key={i}
-                                  onClick={e => { e.stopPropagation(); handleWordClick(sub, token, 'ORIGINAL'); }}
-                                  className="cursor-pointer rounded px-0.5 hover:bg-emerald-100 hover:text-emerald-700 transition-colors"
-                                >
-                                  {token}
-                                </span>
-                              );
-                            })
+                            // 백엔드 토크나이저 결과 우선 사용 (일본어/중국어 형태소 분석 지원)
+                            // words가 없으면 공백 분리 폴백
+                            (sub.words && sub.words.length > 0
+                              ? sub.words.map((w, i) => (
+                                  <span
+                                    key={w.segmentWordId ?? i}
+                                    onClick={e => { e.stopPropagation(); handleWordClick(sub, w.word, 'ORIGINAL'); }}
+                                    className="cursor-pointer rounded px-0.5 hover:bg-emerald-100 hover:text-emerald-700 transition-colors"
+                                  >
+                                    {w.word}
+                                  </span>
+                                ))
+                              : sub.original.split(/(\s+)/).map((token, i) => {
+                                  const isSpace = /^\s+$/.test(token);
+                                  if (isSpace) return <span key={i}>&nbsp;</span>;
+                                  return (
+                                    <span
+                                      key={i}
+                                      onClick={e => { e.stopPropagation(); handleWordClick(sub, token, 'ORIGINAL'); }}
+                                      className="cursor-pointer rounded px-0.5 hover:bg-emerald-100 hover:text-emerald-700 transition-colors"
+                                    >
+                                      {token}
+                                    </span>
+                                  );
+                                })
+                            )
                           ) : (
                             <span className="text-slate-300">원문 없음</span>
                           )}

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -23,7 +23,8 @@ import {
 import { auth } from '@/lib/firebase';
 import { setAuthTokenGetter } from '@/api/client';
 import { registerWithFirebase, getMe, uploadProfileImage as apiUploadProfileImage } from '@/api/auth';
-import { updateProfile } from 'firebase/auth';
+import { apiDelete } from '@/api/client';
+import { updateProfile, sendPasswordResetEmail } from 'firebase/auth';
 
 type AuthState = {
   user: User | null;
@@ -40,6 +41,7 @@ type AuthContextValue = AuthState & {
   clearError: () => void;
   changePassword: (currentPw: string, newPw: string) => Promise<void>;
   deleteAccount: (currentPw: string) => Promise<void>;
+  sendPasswordReset: (email: string) => Promise<void>;
   updateUserProfile: (name: string) => Promise<void>;
   profileImageUrl: string | null;
   uploadProfileImage: (file: File) => Promise<void>;
@@ -183,8 +185,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setError(null);
       if (!user || !user.email) throw new Error('로그인이 필요합니다.');
       try {
+        // Firebase 재인증
         const credential = EmailAuthProvider.credential(user.email, currentPw);
         await reauthenticateWithCredential(user, credential);
+        // 백엔드 데이터 삭제 (프로젝트, 저장 단어 등)
+        await apiDelete('/v1/members/me');
+        // Firebase 계정 삭제
         await deleteUser(user);
         setUser(null);
       } catch (e) {
@@ -195,6 +201,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     [user]
   );
+
+  const sendPasswordReset = useCallback(async (email: string) => {
+    await sendPasswordResetEmail(auth, email);
+  }, []);
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -214,6 +224,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       updateUserProfile,
       profileImageUrl,
       uploadProfileImage,
+      sendPasswordReset,
     }),
     [
       user,
@@ -230,6 +241,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       updateUserProfile,
       profileImageUrl,
       uploadProfileImage,
+      sendPasswordReset,
     ]
   );
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -10,6 +10,7 @@ import { TranslatePage } from '@/app/pages/TranslatePage';
 import { StudyPage } from '@/app/pages/StudyPage';
 import { ProcessingPage } from '@/app/pages/ProcessingPage';
 import { DashboardPage } from '@/app/pages/DashboardPage';
+import { ForgotPasswordPage } from '@/app/pages/ForgotPasswordPage';
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,10 @@ export const router = createBrowserRouter([
   {
     path: '/login',
     element: <LoginPage />,
+  },
+  {
+    path: '/forgot-password',
+    element: <ForgotPasswordPage />,
   },
 
   {


### PR DESCRIPTION
## 작업 개요
회원 탈퇴 API 연동, 비밀번호 찾기 기능, 일본어 중국어 언어 감지 수정
## 관련 이슈
- close #143 

## 작업 내용
- AuthProvider: 회원탈퇴 시 백엔드 DELETE /v1/members/me 호출 추가
- AuthProvider: sendPasswordReset 함수 추가 (Firebase 비밀번호 재설정)
- ForgotPasswordPage: 비밀번호 찾기 페이지 신규 생성
- LoginPage: 비밀번호 찾기 링크 추가
- router.tsx: /forgot-password 라우트 추가
- TranslatePage: 백엔드 토크나이저 결과로 단어 렌더링 (일본어/중국어 형태소 분리)
- ProcessingPage: 알 수 없는 단계 전환 시 색상 사라짐 버그 수정
- StudyPage: 일본어 유의어 언어 감지 수정 (detectLang 폴백)

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
<img width="1906" height="888" alt="스크린샷 2026-05-25 오전 2 17 26" src="https://github.com/user-attachments/assets/6bd3d9a0-9f7f-4d06-9696-683d2e911ff3" />
<img width="1906" height="888" alt="스크린샷 2026-05-25 오전 2 17 39" src="https://github.com/user-attachments/assets/7b4d4702-e3d0-41ad-97a8-891e872f0d36" />
<img width="1906" height="888" alt="스크린샷 2026-05-25 오전 2 17 54" src="https://github.com/user-attachments/assets/448e46a4-a3a4-4484-802c-423dd56e431a" />
<img width="1650" height="637" alt="스크린샷 2026-05-25 오전 2 25 54" src="https://github.com/user-attachments/assets/1d3dc868-1bc8-4ebc-9596-41f8f2359f78" />
<img width="1894" height="925" alt="스크린샷 2026-05-25 오전 2 26 08" src="https://github.com/user-attachments/assets/dcb6cdda-451c-4e16-bc42-75b836fbc00e" />
<img width="1916" height="878" alt="스크린샷 2026-05-25 오전 2 27 09" src="https://github.com/user-attachments/assets/d8e1da48-d714-4379-a1fa-cdc59a608a66" />

## 기타 사항