### PR TITLE
feat: AI 부분 성공 callback 및 fallback 정책 적용

### DIFF
--- a/ai/pipeline/run_pipeline.py
+++ b/ai/pipeline/run_pipeline.py
@@ -43,6 +43,21 @@ from ai.translation import create_translation_service
 
 ProgressCallback = Callable[[CurrentStage, float, dict[str, Any] | None], None]
 
+RECOVERABLE_ISSUE_MESSAGES = {
+    "OCR_FAILED": "OCR processing failed; available non-OCR results were saved.",
+    "TRANSLATION_FAILED": (
+        "Translation processing failed; original recognition results were saved."
+    ),
+    "LEARNING_FAILED": (
+        "Learning analysis failed; available recognition and translation results were saved."
+    ),
+}
+RECOVERABLE_ISSUE_PRIORITY = (
+    "OCR_FAILED",
+    "TRANSLATION_FAILED",
+    "LEARNING_FAILED",
+)
+
 SOFT_SPLIT_WORDS = {
     # English
     "i",
@@ -242,27 +257,36 @@ def run_pipeline(
             pipeline_steps.append("STT")
 
         if job_type in {JobType.FULL_ANALYSIS.value, JobType.OCR_ONLY.value}:
-            _report_progress(progress_callback, CurrentStage.OCR_FRAME_EXTRACTION, 45.0)
-            frames = extract_frames(
-                source_path,
-                directories["frames"],
-                interval_seconds=float(runtime_options["frame_interval"]),
-            )
-            frames = annotate_frame_changes(
-                frames,
-                change_threshold=float(runtime_options["ocr_change_threshold"]),
-            )
-            save_intermediate(resolved_job_id, "frame_extraction", frames)
+            try:
+                _report_progress(progress_callback, CurrentStage.OCR_FRAME_EXTRACTION, 45.0)
+                frames = extract_frames(
+                    source_path,
+                    directories["frames"],
+                    interval_seconds=float(runtime_options["frame_interval"]),
+                )
+                frames = annotate_frame_changes(
+                    frames,
+                    change_threshold=float(runtime_options["ocr_change_threshold"]),
+                )
+                save_intermediate(resolved_job_id, "frame_extraction", frames)
 
-            _report_progress(progress_callback, CurrentStage.OCR_TEXT_DETECTION, 55.0)
-            ocr_items = _run_ocr_stage(normalized_job, frames)
-            save_intermediate(
-                resolved_job_id,
-                "ocr_items",
-                [ocr_item.model_dump(by_alias=True) for ocr_item in ocr_items],
-            )
-            pipeline_steps.append("OCR_FRAME_EXTRACTION")
-            pipeline_steps.append("OCR_TEXT_DETECTION")
+                _report_progress(progress_callback, CurrentStage.OCR_TEXT_DETECTION, 55.0)
+                ocr_items = _run_ocr_stage(normalized_job, frames)
+                save_intermediate(
+                    resolved_job_id,
+                    "ocr_items",
+                    [ocr_item.model_dump(by_alias=True) for ocr_item in ocr_items],
+                )
+                pipeline_steps.append("OCR_FRAME_EXTRACTION")
+                pipeline_steps.append("OCR_TEXT_DETECTION")
+            except Exception as error:
+                if (
+                    job_type != JobType.FULL_ANALYSIS.value
+                    or _is_fatal_processing_error(error)
+                ):
+                    raise
+
+                _append_recoverable_warning(warnings, "OCR_FAILED", error)
 
         resolved_source_language = _resolve_source_language(
             normalized_job.source_language,
@@ -270,38 +294,44 @@ def run_pipeline(
         )
         if _should_run_translation(normalized_job, resolved_source_language):
             _report_progress(progress_callback, CurrentStage.TRANSLATION, 80.0)
-            warnings.extend(
-                _run_translation_stage(
-                    normalized_job,
-                    subtitles,
-                    ocr_items,
-                    resolved_source_language,
+            try:
+                warnings.extend(
+                    _run_translation_stage(
+                        normalized_job,
+                        subtitles,
+                        ocr_items,
+                        resolved_source_language,
+                    )
                 )
-            )
-            subtitles = _split_translated_subtitles_for_rendering(
-                subtitles,
-                target_language=normalized_job.target_language,
-                max_duration_seconds=float(
-                    runtime_options["translated_subtitle_max_seconds"]
-                ),
-                max_text_length=int(runtime_options["translated_subtitle_max_chars"]),
-                min_split_duration_seconds=float(
-                    runtime_options["translated_subtitle_min_split_seconds"]
-                ),
-            )
-            save_intermediate(
-                resolved_job_id,
-                "translation",
-                {
-                    "subtitles": [
-                        subtitle.model_dump(by_alias=True) for subtitle in subtitles
-                    ],
-                    "ocrItems": [
-                        ocr_item.model_dump(by_alias=True) for ocr_item in ocr_items
-                    ],
-                },
-            )
-            pipeline_steps.append("TRANSLATION")
+                subtitles = _split_translated_subtitles_for_rendering(
+                    subtitles,
+                    target_language=normalized_job.target_language,
+                    max_duration_seconds=float(
+                        runtime_options["translated_subtitle_max_seconds"]
+                    ),
+                    max_text_length=int(runtime_options["translated_subtitle_max_chars"]),
+                    min_split_duration_seconds=float(
+                        runtime_options["translated_subtitle_min_split_seconds"]
+                    ),
+                )
+                save_intermediate(
+                    resolved_job_id,
+                    "translation",
+                    {
+                        "subtitles": [
+                            subtitle.model_dump(by_alias=True) for subtitle in subtitles
+                        ],
+                        "ocrItems": [
+                            ocr_item.model_dump(by_alias=True) for ocr_item in ocr_items
+                        ],
+                    },
+                )
+                pipeline_steps.append("TRANSLATION")
+            except Exception as error:
+                if _is_fatal_processing_error(error):
+                    raise
+
+                _append_recoverable_warning(warnings, "TRANSLATION_FAILED", error)
 
         if _should_run_learning_analysis(normalized_job, subtitles):
             _report_progress(progress_callback, CurrentStage.LLM_ANALYSIS, 85.0)
@@ -319,7 +349,7 @@ def run_pipeline(
                     )
                     pipeline_steps.append("LLM_ANALYSIS")
             except Exception as error:
-                warnings.append(f"Learning data generation failed: {error}")
+                _append_recoverable_warning(warnings, "LEARNING_FAILED", error)
 
         _report_progress(progress_callback, CurrentStage.FINALIZING, 90.0)
         result = AnalysisResult(
@@ -332,7 +362,7 @@ def run_pipeline(
                 source_language=resolved_source_language,
                 target_language=normalized_job.target_language,
                 pipeline=pipeline_steps,
-                fallback_used=False,
+                fallback_used=_has_recoverable_warning(warnings),
             ),
             warnings=warnings,
         )
@@ -352,6 +382,40 @@ def run_pipeline(
         return result
     finally:
         cleanup(resolved_job_id, keep_result_files=keep_intermediate_files)
+
+
+def resolve_completion_error(warnings: list[str]) -> tuple[str | None, str | None]:
+    issue_codes = [
+        code
+        for code in RECOVERABLE_ISSUE_PRIORITY
+        if any(warning.startswith(f"{code}:") for warning in warnings)
+    ]
+    if not issue_codes:
+        return None, None
+
+    message = " ".join(RECOVERABLE_ISSUE_MESSAGES[code] for code in issue_codes)
+    return issue_codes[0], message
+
+
+def _append_recoverable_warning(
+    warnings: list[str],
+    issue_code: str,
+    error: Exception,
+) -> None:
+    detail = str(error).strip() or error.__class__.__name__
+    warning = f"{issue_code}: {RECOVERABLE_ISSUE_MESSAGES[issue_code]} Detail: {detail}"
+    if warning not in warnings:
+        warnings.append(warning)
+
+
+def _has_recoverable_warning(warnings: list[str]) -> bool:
+    error_code, _ = resolve_completion_error(warnings)
+    return error_code is not None
+
+
+def _is_fatal_processing_error(error: Exception) -> bool:
+    error_message = str(error).lower()
+    return "out of memory" in error_message or "cuda failed" in error_message
 
 
 def _normalize_job(

--- a/ai/worker/tasks.py
+++ b/ai/worker/tasks.py
@@ -14,7 +14,7 @@ from ai.api.schemas import (
     SourceType,
 )
 from ai.pipeline.callback_client import send_callback
-from ai.pipeline.run_pipeline import run_pipeline
+from ai.pipeline.run_pipeline import resolve_completion_error, run_pipeline
 from ai.pipeline.youtube_service import (
     YoutubeDownloadError,
     YoutubeVideoTooLongError,
@@ -95,6 +95,9 @@ def _execute_job_task(self, job_payload: dict):
             job_id=callback_job_id,
             keep_intermediate_files=True,
         )
+        completion_error_code, completion_error_message = resolve_completion_error(
+            result.warnings
+        )
 
         send_callback(
             CallbackPayload(
@@ -105,8 +108,8 @@ def _execute_job_task(self, job_payload: dict):
                 segments=result.subtitles,
                 ocr_items=result.ocr_items,
                 learning_data=result.learning_data,
-                error_code=None,
-                error_message=None,
+                error_code=completion_error_code,
+                error_message=completion_error_message,
             )
         )
         return result.model_dump(by_alias=True)


### PR DESCRIPTION
## 작업 개요
AI 파이프라인의 일부 단계가 실패하더라도 사용 가능한 결과를 Backend에 저장할 수 있도록
부분 성공 및 fallback 처리 정책을 적용했습니다.

## 관련 이슈
- close #150 

## 작업 내용
- `FULL_ANALYSIS` 중 OCR 처리 실패 시 STT 등 사용 가능한 결과를 유지하도록 수정
- 번역 처리 실패 시 원문 STT/OCR 결과를 유지하도록 수정
- 학습 데이터 생성 실패 시 기존 분석 결과를 유지하도록 수정
- 복구 가능한 실패가 발생한 경우 `metadata.fallbackUsed=true` 반영
- 완료 callback에 부분 성공 오류 정보를 전달하도록 worker callback 처리 수정
- 복수 부분 실패 발생 시 error code 우선순위 적용
- CUDA OOM 등 치명적 오류는 기존과 동일하게 `FAILED` 처리 유지

## 체크리스트 (DoD)
- [ ] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)
## 기타 사항