### PR TITLE
feat: TRANSLATION_ONLY 재처리 payload 지원

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/JobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/JobController.java
@@ -1,10 +1,6 @@
 package com.overlang.api.controller;
 
-import com.overlang.api.dto.job.JobCreateRequest;
-import com.overlang.api.dto.job.JobCreateResponse;
-import com.overlang.api.dto.job.JobDetailResponse;
-import com.overlang.api.dto.job.JobResponse;
-import com.overlang.api.dto.job.JobRetryResponse;
+import com.overlang.api.dto.job.*;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.auth.AuthInterceptor;
 import com.overlang.global.response.ApiResponse;
@@ -59,14 +55,16 @@ public class JobController {
     return ApiResponse.success(response);
   }
 
-  @Operation(summary = "분석 작업 재처리", description = "FAILED 상태의 최신 AI 작업을 동일 프로젝트 기준으로 재처리합니다.")
+  @Operation(summary = "분석 작업 재처리", description = "FAILED 상태의 최신 AI 작업을 요청한 jobType 기준으로 재처리합니다.")
   @PostMapping("/projects/{projectId}/jobs/retry")
   public ApiResponse<JobRetryResponse> retryJob(
-      @PathVariable Long projectId, HttpServletRequest httpServletRequest) {
+      @PathVariable Long projectId,
+      @RequestBody JobRetryRequest request,
+      HttpServletRequest httpServletRequest) {
 
     Long memberId = (Long) httpServletRequest.getAttribute(AuthInterceptor.AUTH_MEMBER_ID);
 
-    JobRetryResponse response = jobService.retryJob(projectId, memberId);
+    JobRetryResponse response = jobService.retryJob(projectId, memberId, request);
 
     return ApiResponse.success(response);
   }

--- a/backend/src/main/java/com/overlang/api/dto/job/JobRetryRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobRetryRequest.java
@@ -1,0 +1,5 @@
+package com.overlang.api.dto.job;
+
+import com.overlang.domain.job.entity.JobType;
+
+public record JobRetryRequest(JobType jobType) {}

--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayload.java
@@ -4,6 +4,7 @@ import com.overlang.domain.common.LanguageCode;
 import com.overlang.domain.job.entity.JobType;
 import com.overlang.domain.job.entity.TranslationProvider;
 import com.overlang.domain.project.entity.SourceType;
+import java.util.List;
 
 public record JobQueuePayload(
     Long jobId,
@@ -16,4 +17,13 @@ public record JobQueuePayload(
     JobType jobType,
     LanguageCode sourceLanguage,
     LanguageCode targetLanguage,
-    TranslationProvider translationProvider) {}
+    TranslationProvider translationProvider,
+    List<SegmentPayload> segments,
+    List<OcrItemPayload> ocrItems) {
+  public record SegmentPayload(Integer seq, Double startTime, Double endTime, String text) {}
+
+  public record OcrItemPayload(
+      Double startTime, Double endTime, String originText, BoundingBoxPayload boundingBox) {}
+
+  public record BoundingBoxPayload(Double x, Double y, Double width, Double height) {}
+}

--- a/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayloadFactory.java
+++ b/backend/src/main/java/com/overlang/domain/job/queue/JobQueuePayloadFactory.java
@@ -2,8 +2,14 @@ package com.overlang.domain.job.queue;
 
 import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.job.entity.JobStatus;
+import com.overlang.domain.job.entity.JobType;
+import com.overlang.domain.job.repository.JobRepository;
+import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.SourceType;
+import com.overlang.domain.segment.repository.SegmentRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,9 +18,17 @@ import org.springframework.stereotype.Component;
 public class JobQueuePayloadFactory {
 
   private final S3UploadService s3UploadService;
+  private final SegmentRepository segmentRepository;
+  private final OcrItemRepository ocrItemRepository;
+  private final JobRepository jobRepository;
 
   public JobQueuePayload create(Project project, Job job) {
     SourceType sourceType = project.getSourceType();
+
+    Job baseJob = findBaseJobIfTranslationOnly(project, job);
+
+    List<JobQueuePayload.SegmentPayload> segments = createSegmentPayloads(baseJob);
+    List<JobQueuePayload.OcrItemPayload> ocrItems = createOcrItemPayloads(baseJob);
 
     return switch (sourceType) {
       case UPLOAD -> {
@@ -31,7 +45,9 @@ public class JobQueuePayloadFactory {
             job.getJobType(),
             job.getSourceLanguage(),
             job.getTargetLanguage(),
-            job.getTranslationProvider());
+            job.getTranslationProvider(),
+            segments,
+            ocrItems);
       }
 
       case YOUTUBE ->
@@ -46,7 +62,52 @@ public class JobQueuePayloadFactory {
               job.getJobType(),
               job.getSourceLanguage(),
               job.getTargetLanguage(),
-              job.getTranslationProvider());
+              job.getTranslationProvider(),
+              segments,
+              ocrItems);
     };
+  }
+
+  private Job findBaseJobIfTranslationOnly(Project project, Job job) {
+    if (job.getJobType() != JobType.TRANSLATION_ONLY) {
+      return null;
+    }
+
+    return jobRepository
+        .findTopByProjectIdAndStatusOrderByCreatedAtDesc(project.getId(), JobStatus.COMPLETED)
+        .orElseThrow(() -> new IllegalStateException("TRANSLATION_ONLY 기준 COMPLETED Job이 없습니다."));
+  }
+
+  private List<JobQueuePayload.SegmentPayload> createSegmentPayloads(Job baseJob) {
+    if (baseJob == null) {
+      return List.of();
+    }
+
+    return segmentRepository.findByJobIdOrderBySeqAsc(baseJob.getId()).stream()
+        .map(
+            segment ->
+                new JobQueuePayload.SegmentPayload(
+                    segment.getSeq(),
+                    segment.getStartTime(),
+                    segment.getEndTime(),
+                    segment.getText()))
+        .toList();
+  }
+
+  private List<JobQueuePayload.OcrItemPayload> createOcrItemPayloads(Job baseJob) {
+    if (baseJob == null) {
+      return List.of();
+    }
+
+    return ocrItemRepository.findByJobIdOrderByStartTimeAsc(baseJob.getId()).stream()
+        .map(
+            ocrItem ->
+                new JobQueuePayload.OcrItemPayload(
+                    ocrItem.getStartTime(),
+                    ocrItem.getEndTime(),
+                    ocrItem.getOriginText(),
+                    new JobQueuePayload.BoundingBoxPayload(
+                        ocrItem.getX(), ocrItem.getY(), ocrItem.getW(), ocrItem.getH())))
+        .toList();
   }
 }

--- a/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/com/overlang/domain/job/repository/JobRepository.java
@@ -17,6 +17,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
   Optional<Job> findTopByProjectIdOrderByCreatedAtDesc(Long projectId);
 
+  Optional<Job> findTopByProjectIdAndStatusOrderByCreatedAtDesc(Long projectId, JobStatus status);
+
   Optional<Job> findByIdAndProjectMemberId(Long jobId, Long memberId);
 
   boolean existsByIdAndProjectMemberId(Long jobId, Long memberId);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -93,15 +93,19 @@ public class JobService {
   }
 
   @Transactional
-  public JobRetryResponse retryJob(Long projectId, Long memberId) {
+  public JobRetryResponse retryJob(Long projectId, Long memberId, JobRetryRequest request) {
     Project project = findProjectByIdAndMemberId(projectId, memberId);
     Job latestJob = findLatestJobByProjectId(project.getId());
+
+    if (request.jobType() == null) {
+      throw new IllegalArgumentException("jobType은 필수입니다.");
+    }
 
     if (latestJob.getStatus() != JobStatus.FAILED) {
       throw new IllegalArgumentException("FAILED 상태의 작업만 재처리할 수 있습니다.");
     }
 
-    Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob));
+    Job savedJob = jobRepository.save(createRetryJobEntity(project, latestJob, request));
 
     enqueueJob(project, savedJob);
 
@@ -194,10 +198,11 @@ public class JobService {
         request.translationProvider());
   }
 
-  private Job createRetryJobEntity(Project project, Job latestJob) {
+  private Job createRetryJobEntity(Project project, Job latestJob, JobRetryRequest request) {
+
     return new Job(
         project,
-        latestJob.getJobType(),
+        request.jobType(),
         latestJob.getSourceLanguage(),
         latestJob.getTargetLanguage(),
         latestJob.getTranslationProvider());


### PR DESCRIPTION
## 작업 개요
TRANSLATION_ONLY 기반 단계별 재처리 payload 지원

## 관련 이슈
- close #152

## 작업 내용
- retry API에 jobType 요청값 추가
- TRANSLATION_ONLY Job 생성 지원
- TRANSLATION_ONLY 시 기존 COMPLETED Job 조회 로직 추가
- Redis Queue payload에 segments 추가
- Redis Queue payload에 ocrItems 추가
- 기존 원문 분석 결과 기반 TRANSLATION_ONLY payload 지원
- JobQueuePayload 구조 확장

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- TRANSLATION_ONLY 요청 시 기존 segments / ocrItems 데이터를 Redis Queue payload에 포함하도록 구현
- AI Worker는 해당 payload를 기준으로 번역만 수행하는 로직 연동 필요