### PR TITLE
feat: 학습 콘텐츠 textType 응답 지원

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/learning/LearningContentResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/learning/LearningContentResponse.java
@@ -1,13 +1,20 @@
 package com.overlang.api.dto.learning;
 
 import com.overlang.domain.learning.entity.LearningContent;
+import com.overlang.domain.word.entity.SelectedTextType;
 
 public record LearningContentResponse(
-    Long learningContentId, String title, String content, Double startTime, Double endTime) {
+    Long learningContentId,
+    SelectedTextType textType,
+    String title,
+    String content,
+    Double startTime,
+    Double endTime) {
 
   public static LearningContentResponse from(LearningContent learningContent) {
     return new LearningContentResponse(
         learningContent.getId(),
+        learningContent.getTextType(),
         learningContent.getTitle(),
         learningContent.getContent(),
         learningContent.getStartTime(),


### PR DESCRIPTION
## 작업 개요
학습 콘텐츠 textType 응답 지원

## 관련 이슈
- close #154 

## 작업 내용
- LearningContentResponse에 textType 필드 추가
- LearningContent → Response DTO textType 매핑 추가
- 학습 콘텐츠 조회 API 응답에 ORIGINAL / TRANSLATION 정보 포함
- 원문 기반 / 번역문 기반 학습 콘텐츠 구분을 위한 응답 필드 추가

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- LearningContent entity에 저장된 textType 값을 학습 콘텐츠 조회 응답에 포함하도록 수정
- FE에서 ORIGINAL / TRANSLATION 기반 표현 구분 가능