### PR TITLE
feat: OCR 라인 정보 저장 및 응답 구조 확장

### DIFF
--- a/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/CallbackOcrItemRequest.java
@@ -1,7 +1,9 @@
 package com.overlang.api.dto.job;
 
 import com.overlang.api.dto.ocr.BoundingBoxRequest;
+import com.overlang.api.dto.ocr.OcrItemLineRequest;
 import com.overlang.api.dto.ocr.OcrStyleRequest;
+import java.util.List;
 
 public record CallbackOcrItemRequest(
     Double startTime,
@@ -10,4 +12,5 @@ public record CallbackOcrItemRequest(
     String translatedText,
     BoundingBoxRequest boundingBox,
     Double confidence,
+    List<OcrItemLineRequest> lines,
     OcrStyleRequest style) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemLineRequest.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemLineRequest.java
@@ -1,0 +1,3 @@
+package com.overlang.api.dto.ocr;
+
+public record OcrItemLineRequest(String originText, BoundingBoxRequest boundingBox) {}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemLineResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemLineResponse.java
@@ -1,0 +1,12 @@
+package com.overlang.api.dto.ocr;
+
+import com.overlang.domain.ocr.entity.OcrItemLine;
+
+public record OcrItemLineResponse(String originText, BoundingBoxResponse boundingBox) {
+
+  public static OcrItemLineResponse from(OcrItemLine line) {
+    return new OcrItemLineResponse(
+        line.getOriginText(),
+        new BoundingBoxResponse(line.getX(), line.getY(), line.getW(), line.getH()));
+  }
+}

--- a/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/ocr/OcrItemResponse.java
@@ -1,6 +1,7 @@
 package com.overlang.api.dto.ocr;
 
 import com.overlang.domain.ocr.entity.OcrItem;
+import java.util.List;
 
 public record OcrItemResponse(
     Long ocrItemId,
@@ -11,6 +12,7 @@ public record OcrItemResponse(
     String translatedText,
     BoundingBoxResponse boundingBox,
     Double confidence,
+    List<OcrItemLineResponse> lines,
     OcrStyleResponse style) {
 
   public static OcrItemResponse from(OcrItem ocrItem) {
@@ -23,6 +25,7 @@ public record OcrItemResponse(
         ocrItem.getTranslatedText(),
         new BoundingBoxResponse(ocrItem.getX(), ocrItem.getY(), ocrItem.getW(), ocrItem.getH()),
         ocrItem.getConfidence(),
+        ocrItem.getLines().stream().map(OcrItemLineResponse::from).toList(),
         new OcrStyleResponse(
             ocrItem.getBackgroundColor(),
             ocrItem.getDominantBackgroundColor(),

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -14,6 +14,7 @@ import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.entity.OcrItem;
+import com.overlang.domain.ocr.entity.OcrItemLine;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.Segment;
@@ -185,30 +186,55 @@ public class JobResultService {
     OcrStyleRequest style = o.style();
     BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
 
-    return new OcrItem(
-        job,
-        o.startTime(),
-        o.endTime(),
-        o.originText(),
-        o.translatedText(),
-        o.boundingBox().x(),
-        o.boundingBox().y(),
-        o.boundingBox().w(),
-        o.boundingBox().h(),
-        o.confidence(),
-        style != null ? style.backgroundColor() : null,
-        style != null ? style.dominantBackgroundColor() : null,
-        style != null ? style.textColor() : null,
-        blurRegion != null ? blurRegion.x() : null,
-        blurRegion != null ? blurRegion.y() : null,
-        blurRegion != null ? blurRegion.w() : null,
-        blurRegion != null ? blurRegion.h() : null,
-        style != null ? style.fontSizeRatio() : null,
-        style != null ? style.fontWeight() : null,
-        style != null ? style.textAlign() : null,
-        getAnimationType(style),
-        getAnimationStartTime(style),
-        getAnimationEndTime(style));
+    OcrItem ocrItem =
+        new OcrItem(
+            job,
+            o.startTime(),
+            o.endTime(),
+            o.originText(),
+            o.translatedText(),
+            o.boundingBox().x(),
+            o.boundingBox().y(),
+            o.boundingBox().w(),
+            o.boundingBox().h(),
+            o.confidence(),
+            style != null ? style.backgroundColor() : null,
+            style != null ? style.dominantBackgroundColor() : null,
+            style != null ? style.textColor() : null,
+            blurRegion != null ? blurRegion.x() : null,
+            blurRegion != null ? blurRegion.y() : null,
+            blurRegion != null ? blurRegion.w() : null,
+            blurRegion != null ? blurRegion.h() : null,
+            style != null ? style.fontSizeRatio() : null,
+            style != null ? style.fontWeight() : null,
+            style != null ? style.textAlign() : null,
+            getAnimationType(style),
+            getAnimationStartTime(style),
+            getAnimationEndTime(style));
+
+    if (o.lines() != null) {
+      for (int i = 0; i < o.lines().size(); i++) {
+        var lineRequest = o.lines().get(i);
+
+        if (lineRequest.boundingBox() == null) {
+          continue;
+        }
+
+        OcrItemLine line =
+            OcrItemLine.create(
+                ocrItem,
+                i + 1,
+                lineRequest.originText(),
+                lineRequest.boundingBox().x(),
+                lineRequest.boundingBox().y(),
+                lineRequest.boundingBox().w(),
+                lineRequest.boundingBox().h());
+
+        ocrItem.addLine(line);
+      }
+    }
+
+    return ocrItem;
   }
 
   private String getAnimationType(OcrStyleRequest style) {

--- a/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItem.java
@@ -3,6 +3,8 @@ package com.overlang.domain.ocr.entity;
 import com.overlang.domain.common.BaseTimeEntity;
 import com.overlang.domain.job.entity.Job;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 
 @Entity
@@ -84,6 +86,9 @@ public class OcrItem extends BaseTimeEntity {
   @Column(name = "animation_end_time")
   private Double animationEndTime;
 
+  @OneToMany(mappedBy = "ocrItem", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<OcrItemLine> lines = new ArrayList<>();
+
   public OcrItem(
       Job job,
       Double startTime,
@@ -131,5 +136,9 @@ public class OcrItem extends BaseTimeEntity {
     this.animationType = animationType;
     this.animationStartTime = animationStartTime;
     this.animationEndTime = animationEndTime;
+  }
+
+  public void addLine(OcrItemLine line) {
+    this.lines.add(line);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItemLine.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/entity/OcrItemLine.java
@@ -1,0 +1,67 @@
+package com.overlang.domain.ocr.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ocr_item_lines")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OcrItemLine {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "ocr_item_id", nullable = false)
+  private OcrItem ocrItem;
+
+  @Column(name = "line_order", nullable = false)
+  private Integer lineOrder;
+
+  @Column(name = "origin_text", nullable = false, columnDefinition = "TEXT")
+  private String originText;
+
+  @Column(nullable = false)
+  private Double x;
+
+  @Column(nullable = false)
+  private Double y;
+
+  @Column(nullable = false)
+  private Double w;
+
+  @Column(nullable = false)
+  private Double h;
+
+  private OcrItemLine(
+      OcrItem ocrItem,
+      Integer lineOrder,
+      String originText,
+      Double x,
+      Double y,
+      Double w,
+      Double h) {
+    this.ocrItem = ocrItem;
+    this.lineOrder = lineOrder;
+    this.originText = originText;
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+  }
+
+  public static OcrItemLine create(
+      OcrItem ocrItem,
+      Integer lineOrder,
+      String originText,
+      Double x,
+      Double y,
+      Double w,
+      Double h) {
+    return new OcrItemLine(ocrItem, lineOrder, originText, x, y, w, h);
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/repository/OcrItemRepository.java
@@ -3,8 +3,17 @@ package com.overlang.domain.ocr.repository;
 import com.overlang.domain.ocr.entity.OcrItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OcrItemRepository extends JpaRepository<OcrItem, Long> {
+  @Query(
+      """
+      SELECT DISTINCT oi
+      FROM OcrItem oi
+      LEFT JOIN FETCH oi.lines
+      WHERE oi.job.id = :jobId
+      ORDER BY oi.startTime ASC
+      """)
   List<OcrItem> findByJobIdOrderByStartTimeAsc(Long jobId);
 
   void deleteByJobId(Long jobId);


### PR DESCRIPTION
## 작업 개요
OCR line 정보를 저장하고 조회할 수 있도록 OCR 응답 구조 확장

## 관련 이슈
- close #156

## 작업 내용
- `ocr_item_lines` 테이블 추가
- `OcrItem`과 `OcrItemLine` 연관관계 추가
- OCR callback request 구조에 `lines` 필드 추가
- OCR callback 저장 시 line 정보 함께 저장 처리
- OCR 조회 API 응답에 `lines` 정보 포함
- OCR item 삭제 시 `ocr_item_lines` cascade 삭제 처리 확인

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- line 단위는 `originText` 및 `boundingBox`만 저장
- block 단위 번역은 기존 `translatedText` 유지
- 기존 OCR style / animation 구조 유지