### PR TITLE
feat: 삭제된 Job Worker skip 처리 지원

### DIFF
--- a/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
+++ b/backend/src/main/java/com/overlang/api/controller/InternalJobController.java
@@ -2,6 +2,7 @@ package com.overlang.api.controller;
 
 import com.overlang.api.dto.job.JobCallbackRequest;
 import com.overlang.api.dto.job.JobCallbackResponse;
+import com.overlang.api.dto.job.JobValidResponse;
 import com.overlang.domain.job.service.JobService;
 import com.overlang.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,16 @@ import org.springframework.web.bind.annotation.*;
 public class InternalJobController {
 
   private final JobService jobService;
+
+  @Operation(
+      summary = "AI 작업 유효성 확인",
+      description = "AI Worker가 분석 시작 전 Job이 아직 유효한지 확인하는 내부 API입니다.")
+  @GetMapping("/{jobId}/valid")
+  public ApiResponse<JobValidResponse> validateJob(@PathVariable Long jobId) {
+    JobValidResponse response = jobService.validateJob(jobId);
+
+    return ApiResponse.success(response);
+  }
 
   @Operation(
       summary = "AI 작업 콜백 처리",

--- a/backend/src/main/java/com/overlang/api/dto/job/JobValidResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobValidResponse.java
@@ -1,0 +1,6 @@
+package com.overlang.api.dto.job;
+
+public record JobValidResponse(
+        boolean valid
+) {
+}

--- a/backend/src/main/java/com/overlang/api/dto/job/JobValidResponse.java
+++ b/backend/src/main/java/com/overlang/api/dto/job/JobValidResponse.java
@@ -1,6 +1,3 @@
 package com.overlang.api.dto.job;
 
-public record JobValidResponse(
-        boolean valid
-) {
-}
+public record JobValidResponse(boolean valid) {}

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -92,6 +92,11 @@ public class JobService {
     return JobDetailResponse.from(job);
   }
 
+  @Transactional(readOnly = true)
+  public JobValidResponse validateJob(Long jobId) {
+    return new JobValidResponse(jobRepository.existsById(jobId));
+  }
+
   @Transactional
   public JobRetryResponse retryJob(Long projectId, Long memberId, JobRetryRequest request) {
     Project project = findProjectByIdAndMemberId(projectId, memberId);

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -128,7 +128,13 @@ public class JobService {
     workerAuthService.validateWorkerSecret(requestWorkerSecret);
     validateCallbackJobId(pathJobId, request.jobId());
 
-    Job job = findJobById(pathJobId);
+    var optionalJob = jobRepository.findById(pathJobId);
+
+    if (optionalJob.isEmpty()) {
+      return new JobCallbackResponse(pathJobId, false);
+    }
+
+    Job job = optionalJob.get();
 
     switch (request.status()) {
       case RUNNING -> handleRunningCallback(job, request);


### PR DESCRIPTION
## 작업 개요
삭제된 프로젝트/Job이 Redis Queue에 남아있는 경우 Worker가 안전하게 skip 처리할 수 있도록 Job 유효성 검증 API 및 callback 방어 로직 추가

## 관련 이슈
- close #158

## 작업 내용
- Worker용 Job 유효성 확인 API 추가
- `GET /api/v1/internal/jobs/{jobId}/valid` 엔드포인트 구현
- 존재하는 Job 여부 기반 valid true/false 반환 처리
- 삭제된 Job callback 요청 무시 처리 추가
- hard delete 이후 callback 요청 시 서버 오류가 발생하지 않도록 방어 로직 추가

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [x] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 현재 Worker 연동 전 단계이며, Worker에서 분석 시작 전 valid API 호출 후 invalid(false)인 경우 skip 처리 필요
- 프로젝트/Job 삭제 정책은 기존 hard delete 정책 유지