### PR TITLE
refactor: 서비스 계층 책임 분리 및 중복 코드 제거

### DIFF
--- a/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
+++ b/backend/src/main/java/com/overlang/domain/cache/service/ResultCopyService.java
@@ -21,25 +21,51 @@ public class ResultCopyService {
     copyOcrItems(sourceJob, targetJob);
   }
 
+  private Segment copySegment(Segment segment, Job targetJob) {
+    return new Segment(
+        targetJob,
+        segment.getStartTime(),
+        segment.getEndTime(),
+        segment.getSeq(),
+        segment.getText(),
+        segment.getTranslatedText(),
+        segment.getLanguageCode());
+  }
+
   private void copySegments(Job sourceJob, Job targetJob) {
 
     List<Segment> sourceSegments = segmentRepository.findByJobIdOrderBySeqAsc(sourceJob.getId());
 
     List<Segment> copiedSegments =
-        sourceSegments.stream()
-            .map(
-                segment ->
-                    new Segment(
-                        targetJob,
-                        segment.getStartTime(),
-                        segment.getEndTime(),
-                        segment.getSeq(),
-                        segment.getText(),
-                        segment.getTranslatedText(),
-                        segment.getLanguageCode()))
-            .toList();
-
+        sourceSegments.stream().map(segment -> copySegment(segment, targetJob)).toList();
     segmentRepository.saveAll(copiedSegments);
+  }
+
+  private OcrItem copyOcrItem(OcrItem item, Job targetJob) {
+    return new OcrItem(
+        targetJob,
+        item.getStartTime(),
+        item.getEndTime(),
+        item.getOriginText(),
+        item.getTranslatedText(),
+        item.getX(),
+        item.getY(),
+        item.getW(),
+        item.getH(),
+        item.getConfidence(),
+        item.getBackgroundColor(),
+        item.getDominantBackgroundColor(),
+        item.getTextColor(),
+        item.getBlurX(),
+        item.getBlurY(),
+        item.getBlurW(),
+        item.getBlurH(),
+        item.getFontSizeRatio(),
+        item.getFontWeight(),
+        item.getTextAlign(),
+        item.getAnimationType(),
+        item.getAnimationStartTime(),
+        item.getAnimationEndTime());
   }
 
   private void copyOcrItems(Job sourceJob, Job targetJob) {
@@ -48,34 +74,7 @@ public class ResultCopyService {
         ocrItemRepository.findByJobIdOrderByStartTimeAsc(sourceJob.getId());
 
     List<OcrItem> copiedOcrItems =
-        sourceOcrItems.stream()
-            .map(
-                item ->
-                    new OcrItem(
-                        targetJob,
-                        item.getStartTime(),
-                        item.getEndTime(),
-                        item.getOriginText(),
-                        item.getTranslatedText(),
-                        item.getX(),
-                        item.getY(),
-                        item.getW(),
-                        item.getH(),
-                        item.getConfidence(),
-                        item.getBackgroundColor(),
-                        item.getDominantBackgroundColor(),
-                        item.getTextColor(),
-                        item.getBlurX(),
-                        item.getBlurY(),
-                        item.getBlurW(),
-                        item.getBlurH(),
-                        item.getFontSizeRatio(),
-                        item.getFontWeight(),
-                        item.getTextAlign(),
-                        item.getAnimationType(),
-                        item.getAnimationStartTime(),
-                        item.getAnimationEndTime()))
-            .toList();
+        sourceOcrItems.stream().map(item -> copyOcrItem(item, targetJob)).toList();
 
     ocrItemRepository.saveAll(copiedOcrItems);
   }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,8 +1,6 @@
 package com.overlang.domain.job.service;
 
-import com.overlang.api.dto.job.CallbackLearningDataRequest;
-import com.overlang.api.dto.job.CallbackOcrItemRequest;
-import com.overlang.api.dto.job.JobCallbackRequest;
+import com.overlang.api.dto.job.*;
 import com.overlang.api.dto.ocr.BlurRegionRequest;
 import com.overlang.api.dto.ocr.OcrItemResponse;
 import com.overlang.api.dto.ocr.OcrStyleRequest;
@@ -109,22 +107,15 @@ public class JobResultService {
     learningContentRepository.deleteByJobId(jobId);
   }
 
+  private Segment toSegment(Job job, CallbackSegmentRequest s) {
+    return new Segment(
+        job, s.startTime(), s.endTime(), s.seq(), s.text(), s.translatedText(), s.languageCode());
+  }
+
   public void saveSegments(Job job, JobCallbackRequest request) {
     if (request.segments() == null) return;
 
-    List<Segment> segments =
-        request.segments().stream()
-            .map(
-                s ->
-                    new Segment(
-                        job,
-                        s.startTime(),
-                        s.endTime(),
-                        s.seq(),
-                        s.text(),
-                        s.translatedText(),
-                        s.languageCode()))
-            .toList();
+    List<Segment> segments = request.segments().stream().map(s -> toSegment(job, s)).toList();
 
     List<Segment> savedSegments = segmentRepository.saveAll(segments);
 
@@ -249,24 +240,25 @@ public class JobResultService {
     return style != null && style.animation() != null ? style.animation().endTime() : null;
   }
 
+  private LearningContent toLearningContent(Job job, CallbackLearningContentRequest content) {
+
+    return new LearningContent(
+        job,
+        content.contentType(),
+        content.textType(),
+        content.title(),
+        content.content(),
+        content.startTime(),
+        content.endTime());
+  }
+
   public void saveLearningContents(Job job, CallbackLearningDataRequest learningData) {
     if (learningData == null || learningData.contents() == null) {
       return;
     }
 
     List<LearningContent> learningContents =
-        learningData.contents().stream()
-            .map(
-                content ->
-                    new LearningContent(
-                        job,
-                        content.contentType(),
-                        content.textType(),
-                        content.title(),
-                        content.content(),
-                        content.startTime(),
-                        content.endTime()))
-            .toList();
+        learningData.contents().stream().map(content -> toLearningContent(job, content)).toList();
 
     learningContentRepository.saveAll(learningContents);
   }

--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -1,9 +1,7 @@
 package com.overlang.domain.job.service;
 
 import com.overlang.api.dto.job.*;
-import com.overlang.api.dto.ocr.BlurRegionRequest;
 import com.overlang.api.dto.ocr.OcrItemResponse;
-import com.overlang.api.dto.ocr.OcrStyleRequest;
 import com.overlang.api.dto.segment.SegmentResponse;
 import com.overlang.api.dto.segment.SegmentWordResponse;
 import com.overlang.domain.common.LanguageCode;
@@ -12,8 +10,8 @@ import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.repository.LearningContentRepository;
 import com.overlang.domain.ocr.entity.OcrItem;
-import com.overlang.domain.ocr.entity.OcrItemLine;
 import com.overlang.domain.ocr.repository.OcrItemRepository;
+import com.overlang.domain.ocr.service.OcrItemFactory;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.entity.SegmentWord;
@@ -40,6 +38,7 @@ public class JobResultService {
   private final LearningContentRepository learningContentRepository;
   private final SavedWordRepository savedWordRepository;
   private final SegmentWordTokenizerProvider tokenizerProvider;
+  private final OcrItemFactory ocrItemFactory;
 
   @Transactional(readOnly = true)
   public List<SegmentResponse> getSegments(Long jobId, Long memberId) {
@@ -168,76 +167,9 @@ public class JobResultService {
   public void saveOcrItems(Job job, JobCallbackRequest request) {
     if (request.ocrItems() == null) return;
 
-    List<OcrItem> ocrItems = request.ocrItems().stream().map(o -> toOcrItem(job, o)).toList();
-
+    List<OcrItem> ocrItems =
+        request.ocrItems().stream().map(o -> ocrItemFactory.create(job, o)).toList();
     ocrItemRepository.saveAll(ocrItems);
-  }
-
-  private OcrItem toOcrItem(Job job, CallbackOcrItemRequest o) {
-    OcrStyleRequest style = o.style();
-    BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
-
-    OcrItem ocrItem =
-        new OcrItem(
-            job,
-            o.startTime(),
-            o.endTime(),
-            o.originText(),
-            o.translatedText(),
-            o.boundingBox().x(),
-            o.boundingBox().y(),
-            o.boundingBox().w(),
-            o.boundingBox().h(),
-            o.confidence(),
-            style != null ? style.backgroundColor() : null,
-            style != null ? style.dominantBackgroundColor() : null,
-            style != null ? style.textColor() : null,
-            blurRegion != null ? blurRegion.x() : null,
-            blurRegion != null ? blurRegion.y() : null,
-            blurRegion != null ? blurRegion.w() : null,
-            blurRegion != null ? blurRegion.h() : null,
-            style != null ? style.fontSizeRatio() : null,
-            style != null ? style.fontWeight() : null,
-            style != null ? style.textAlign() : null,
-            getAnimationType(style),
-            getAnimationStartTime(style),
-            getAnimationEndTime(style));
-
-    if (o.lines() != null) {
-      for (int i = 0; i < o.lines().size(); i++) {
-        var lineRequest = o.lines().get(i);
-
-        if (lineRequest.boundingBox() == null) {
-          continue;
-        }
-
-        OcrItemLine line =
-            OcrItemLine.create(
-                ocrItem,
-                i + 1,
-                lineRequest.originText(),
-                lineRequest.boundingBox().x(),
-                lineRequest.boundingBox().y(),
-                lineRequest.boundingBox().w(),
-                lineRequest.boundingBox().h());
-
-        ocrItem.addLine(line);
-      }
-    }
-
-    return ocrItem;
-  }
-
-  private String getAnimationType(OcrStyleRequest style) {
-    return style != null && style.animation() != null ? style.animation().type() : null;
-  }
-
-  private Double getAnimationStartTime(OcrStyleRequest style) {
-    return style != null && style.animation() != null ? style.animation().startTime() : null;
-  }
-
-  private Double getAnimationEndTime(OcrStyleRequest style) {
-    return style != null && style.animation() != null ? style.animation().endTime() : null;
   }
 
   private LearningContent toLearningContent(Job job, CallbackLearningContentRequest content) {

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -3,7 +3,6 @@ package com.overlang.domain.job.service;
 import com.overlang.api.dto.job.*;
 import com.overlang.domain.cache.service.ResultCacheService;
 import com.overlang.domain.cache.service.ResultCopyService;
-import com.overlang.domain.file.service.S3UploadService;
 import com.overlang.domain.job.entity.CurrentStage;
 import com.overlang.domain.job.entity.Job;
 import com.overlang.domain.job.entity.JobStatus;
@@ -16,7 +15,6 @@ import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.repository.ProjectRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,16 +24,12 @@ public class JobService {
 
   private final ProjectRepository projectRepository;
   private final JobRepository jobRepository;
-  private final S3UploadService s3UploadService;
   private final JobQueueProducer jobQueueProducer;
   private final ResultCacheService resultCacheService;
   private final ResultCopyService resultCopyService;
   private final JobResultService jobResultService;
   private final JobQueuePayloadFactory jobQueuePayloadFactory;
   private final WorkerAuthService workerAuthService;
-
-  @Value("${worker.secret}")
-  private String workerSecret;
 
   @Transactional
   public JobCreateResponse createJob(Long projectId, Long memberId, JobCreateRequest request) {
@@ -150,12 +144,6 @@ public class JobService {
     if (!pathJobId.equals(bodyJobId)) {
       throw new IllegalArgumentException("URI jobId와 Body jobId가 일치하지 않습니다.");
     }
-  }
-
-  private Job findJobById(Long jobId) {
-    return jobRepository
-        .findById(jobId)
-        .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
   }
 
   private void handleRunningCallback(Job job, JobCallbackRequest request) {

--- a/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
+++ b/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
@@ -27,6 +27,11 @@ public class LearningContentService {
     List<LearningContent> learningContents =
         learningContentRepository.findByJobIdOrderByStartTimeAscIdAsc(jobId);
 
+    return toLearningContentsResponse(jobId, learningContents);
+  }
+
+  private LearningContentsResponse toLearningContentsResponse(
+      Long jobId, List<LearningContent> learningContents) {
     Map<LearningContentType, List<LearningContentResponse>> contentsByType =
         learningContents.stream()
             .collect(

--- a/backend/src/main/java/com/overlang/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/overlang/domain/member/service/MemberService.java
@@ -61,11 +61,8 @@ public class MemberService {
 
   @Transactional
   public ProfileImageUploadResponse uploadProfileImage(Long memberId, MultipartFile file) {
-    Member member =
-        memberRepository
-            .findById(memberId)
-            .orElseThrow(() -> new UnauthorizedException("Member not found"));
 
+    Member member = findMemberById(memberId);
     String oldProfileImageUrl = member.getProfileImageUrl();
 
     String newProfileImageUrl = s3UploadService.uploadProfileImage(file, memberId);
@@ -77,5 +74,11 @@ public class MemberService {
     }
 
     return new ProfileImageUploadResponse(newProfileImageUrl);
+  }
+
+  private Member findMemberById(Long memberId) {
+    return memberRepository
+        .findById(memberId)
+        .orElseThrow(() -> new UnauthorizedException("Member not found"));
   }
 }

--- a/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
+++ b/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
@@ -26,28 +26,41 @@ public class MemberWithdrawService {
   private final S3UploadService s3UploadService;
 
   public void withdraw(Long memberId) {
+    Member member = findMemberById(memberId);
 
-    Member member =
-        memberRepository
-            .findById(memberId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    deleteMemberProjects(memberId);
+    savedWordRepository.deleteByMemberId(memberId);
+    deleteProfileImage(member);
+    deleteFirebaseUser(member);
 
+    memberRepository.delete(member);
+  }
+
+  private Member findMemberById(Long memberId) {
+    return memberRepository
+        .findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+  }
+
+  private void deleteMemberProjects(Long memberId) {
     List<Project> projects = projectRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
 
     for (Project project : projects) {
       projectService.deleteProject(memberId, project.getId());
     }
+  }
 
-    savedWordRepository.deleteByMemberId(memberId);
+  private void deleteProfileImage(Member member) {
+    if (member.getProfileImageUrl() != null && !member.getProfileImageUrl().isBlank()) {
+      s3UploadService.deleteFileByUrl(member.getProfileImageUrl());
+    }
+  }
 
-    s3UploadService.deleteFileByUrl(member.getProfileImageUrl());
-
+  private void deleteFirebaseUser(Member member) {
     try {
       FirebaseAuth.getInstance().deleteUser(member.getFirebaseUid());
     } catch (FirebaseAuthException e) {
       throw new IllegalArgumentException("Firebase 회원 삭제 중 오류가 발생했습니다.");
     }
-
-    memberRepository.delete(member);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/ocr/service/OcrItemFactory.java
+++ b/backend/src/main/java/com/overlang/domain/ocr/service/OcrItemFactory.java
@@ -1,0 +1,90 @@
+package com.overlang.domain.ocr.service;
+
+import com.overlang.api.dto.job.CallbackOcrItemRequest;
+import com.overlang.api.dto.ocr.BlurRegionRequest;
+import com.overlang.api.dto.ocr.OcrStyleRequest;
+import com.overlang.domain.job.entity.Job;
+import com.overlang.domain.ocr.entity.OcrItem;
+import com.overlang.domain.ocr.entity.OcrItemLine;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OcrItemFactory {
+
+  public OcrItem create(Job job, CallbackOcrItemRequest request) {
+    OcrStyleRequest style = request.style();
+    BlurRegionRequest blurRegion = style != null ? style.blurRegion() : null;
+
+    OcrItem ocrItem =
+        new OcrItem(
+            job,
+            request.startTime(),
+            request.endTime(),
+            request.originText(),
+            request.translatedText(),
+            request.boundingBox().x(),
+            request.boundingBox().y(),
+            request.boundingBox().w(),
+            request.boundingBox().h(),
+            request.confidence(),
+            style != null ? style.backgroundColor() : null,
+            style != null ? style.dominantBackgroundColor() : null,
+            style != null ? style.textColor() : null,
+            blurRegion != null ? blurRegion.x() : null,
+            blurRegion != null ? blurRegion.y() : null,
+            blurRegion != null ? blurRegion.w() : null,
+            blurRegion != null ? blurRegion.h() : null,
+            style != null ? style.fontSizeRatio() : null,
+            style != null ? style.fontWeight() : null,
+            style != null ? style.textAlign() : null,
+            getAnimationType(style),
+            getAnimationStartTime(style),
+            getAnimationEndTime(style));
+
+    addLines(ocrItem, request);
+
+    return ocrItem;
+  }
+
+  private void addLines(OcrItem ocrItem, CallbackOcrItemRequest request) {
+    if (request.lines() == null) {
+      return;
+    }
+
+    for (int i = 0; i < request.lines().size(); i++) {
+      var lineRequest = request.lines().get(i);
+
+      if (lineRequest.boundingBox() == null) {
+        continue;
+      }
+
+      OcrItemLine line =
+          OcrItemLine.create(
+              ocrItem,
+              i + 1,
+              lineRequest.originText(),
+              lineRequest.boundingBox().x(),
+              lineRequest.boundingBox().y(),
+              lineRequest.boundingBox().w(),
+              lineRequest.boundingBox().h());
+
+      ocrItem.addLine(line);
+    }
+  }
+
+  private boolean hasAnimation(OcrStyleRequest style) {
+    return style != null && style.animation() != null;
+  }
+
+  private String getAnimationType(OcrStyleRequest style) {
+    return hasAnimation(style) ? style.animation().type() : null;
+  }
+
+  private Double getAnimationStartTime(OcrStyleRequest style) {
+    return hasAnimation(style) ? style.animation().startTime() : null;
+  }
+
+  private Double getAnimationEndTime(OcrStyleRequest style) {
+    return hasAnimation(style) ? style.animation().endTime() : null;
+  }
+}

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -83,17 +83,19 @@ public class ProjectService {
   @Transactional(readOnly = true)
   public List<ProjectResponse> getProjects(Long memberId) {
     return projectRepository.findByMemberIdOrderByCreatedAtDesc(memberId).stream()
-        .map(
-            project ->
-                new ProjectResponse(
-                    project.getId(),
-                    project.getTitle(),
-                    project.getSourceType(),
-                    project.getSourceUrl(),
-                    project.getFileUrl(),
-                    project.getStatus(),
-                    project.getCreatedAt()))
+        .map(this::toProjectResponse)
         .toList();
+  }
+
+  private ProjectResponse toProjectResponse(Project project) {
+    return new ProjectResponse(
+        project.getId(),
+        project.getTitle(),
+        project.getSourceType(),
+        project.getSourceUrl(),
+        project.getFileUrl(),
+        project.getStatus(),
+        project.getCreatedAt());
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -177,15 +177,7 @@ public class ProjectService {
     savedWordRepository.deleteBySegmentIdsAndWordType(segmentIds, SegmentWordType.TRANSLATION);
 
     segmentWordRepository.deleteBySegmentIdInAndWordType(segmentIds, SegmentWordType.TRANSLATION);
-    Map<Long, String> translatedTextBySegmentId =
-        request.segments().stream()
-            .collect(
-                Collectors.toMap(
-                    ProjectResultSegmentUpdateRequest::segmentId,
-                    ProjectResultSegmentUpdateRequest::translatedText));
-
-    segments.forEach(
-        segment -> segment.updateTranslatedText(translatedTextBySegmentId.get(segment.getId())));
+    updateTranslatedTexts(segments, request.segments());
     List<SegmentWord> newTranslatedWords = createTranslationSegmentWords(segments);
 
     List<SegmentWord> savedTranslatedWords = segmentWordRepository.saveAll(newTranslatedWords);
@@ -217,6 +209,19 @@ public class ProjectService {
             .toList();
 
     return new ProjectResultUpdateResponse(project.getId(), segmentResponses);
+  }
+
+  private void updateTranslatedTexts(
+      List<Segment> segments, List<ProjectResultSegmentUpdateRequest> segmentRequests) {
+    Map<Long, String> translatedTextBySegmentId =
+        segmentRequests.stream()
+            .collect(
+                Collectors.toMap(
+                    ProjectResultSegmentUpdateRequest::segmentId,
+                    ProjectResultSegmentUpdateRequest::translatedText));
+
+    segments.forEach(
+        segment -> segment.updateTranslatedText(translatedTextBySegmentId.get(segment.getId())));
   }
 
   private void validateSegments(List<Segment> segments, List<Long> segmentIds, Long projectId) {

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -173,16 +173,7 @@ public class ProjectService {
 
     List<Segment> segments = segmentRepository.findByIdIn(segmentIds);
 
-    if (segments.size() != segmentIds.size()) {
-      throw new IllegalArgumentException("존재하지 않는 segment가 포함되어 있습니다.");
-    }
-    boolean hasInvalidSegment =
-        segments.stream()
-            .anyMatch(segment -> !segment.getJob().getProject().getId().equals(projectId));
-
-    if (hasInvalidSegment) {
-      throw new IllegalArgumentException("다른 프로젝트의 segment는 수정할 수 없습니다.");
-    }
+    validateSegments(segments, segmentIds, projectId);
     savedWordRepository.deleteBySegmentIdsAndWordType(segmentIds, SegmentWordType.TRANSLATION);
 
     segmentWordRepository.deleteBySegmentIdInAndWordType(segmentIds, SegmentWordType.TRANSLATION);
@@ -226,6 +217,20 @@ public class ProjectService {
             .toList();
 
     return new ProjectResultUpdateResponse(project.getId(), segmentResponses);
+  }
+
+  private void validateSegments(List<Segment> segments, List<Long> segmentIds, Long projectId) {
+    if (segments.size() != segmentIds.size()) {
+      throw new IllegalArgumentException("존재하지 않는 segment가 포함되어 있습니다.");
+    }
+
+    boolean hasInvalidSegment =
+        segments.stream()
+            .anyMatch(segment -> !segment.getJob().getProject().getId().equals(projectId));
+
+    if (hasInvalidSegment) {
+      throw new IllegalArgumentException("다른 프로젝트의 segment는 수정할 수 없습니다.");
+    }
   }
 
   private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -49,23 +49,7 @@ public class ProjectService {
             .findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-    String youtubeVideoId = null;
-
-    if (request.sourceType() == SourceType.YOUTUBE) {
-      youtubeVideoId = YoutubeUrlUtils.extractVideoId(request.sourceUrl());
-    }
-
-    Project project =
-        new Project(
-            member,
-            request.title(),
-            request.sourceType(),
-            request.sourceUrl(),
-            youtubeVideoId,
-            request.fileUrl(),
-            request.fileKey());
-
-    Project savedProject = projectRepository.save(project);
+    Project savedProject = projectRepository.save(createProjectEntity(member, request));
 
     return new ProjectCreateResponse(
         savedProject.getId(),
@@ -77,6 +61,23 @@ public class ProjectService {
         savedProject.getFileKey(),
         savedProject.getStatus(),
         savedProject.getCreatedAt());
+  }
+
+  private Project createProjectEntity(Member member, ProjectCreateRequest request) {
+    String youtubeVideoId = null;
+
+    if (request.sourceType() == SourceType.YOUTUBE) {
+      youtubeVideoId = YoutubeUrlUtils.extractVideoId(request.sourceUrl());
+    }
+
+    return new Project(
+        member,
+        request.title(),
+        request.sourceType(),
+        request.sourceUrl(),
+        youtubeVideoId,
+        request.fileUrl(),
+        request.fileKey());
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -182,6 +182,27 @@ public class ProjectService {
 
     List<SegmentWord> savedTranslatedWords = segmentWordRepository.saveAll(newTranslatedWords);
 
+    List<ProjectResultSegmentResponse> segmentResponses =
+        createProjectResultSegmentResponses(segments, savedTranslatedWords);
+
+    return new ProjectResultUpdateResponse(project.getId(), segmentResponses);
+  }
+
+  private void updateTranslatedTexts(
+      List<Segment> segments, List<ProjectResultSegmentUpdateRequest> segmentRequests) {
+    Map<Long, String> translatedTextBySegmentId =
+        segmentRequests.stream()
+            .collect(
+                Collectors.toMap(
+                    ProjectResultSegmentUpdateRequest::segmentId,
+                    ProjectResultSegmentUpdateRequest::translatedText));
+
+    segments.forEach(
+        segment -> segment.updateTranslatedText(translatedTextBySegmentId.get(segment.getId())));
+  }
+
+  private List<ProjectResultSegmentResponse> createProjectResultSegmentResponses(
+      List<Segment> segments, List<SegmentWord> savedTranslatedWords) {
     Map<Long, List<ProjectResultSegmentResponse.ProjectResultSegmentWordResponse>>
         translatedWordsBySegmentId =
             savedTranslatedWords.stream()
@@ -198,30 +219,14 @@ public class ProjectService {
                                     segmentWord.getEndTime()),
                             Collectors.toList())));
 
-    List<ProjectResultSegmentResponse> segmentResponses =
-        segments.stream()
-            .map(
-                segment ->
-                    new ProjectResultSegmentResponse(
-                        segment.getId(),
-                        segment.getTranslatedText(),
-                        translatedWordsBySegmentId.getOrDefault(segment.getId(), List.of())))
-            .toList();
-
-    return new ProjectResultUpdateResponse(project.getId(), segmentResponses);
-  }
-
-  private void updateTranslatedTexts(
-      List<Segment> segments, List<ProjectResultSegmentUpdateRequest> segmentRequests) {
-    Map<Long, String> translatedTextBySegmentId =
-        segmentRequests.stream()
-            .collect(
-                Collectors.toMap(
-                    ProjectResultSegmentUpdateRequest::segmentId,
-                    ProjectResultSegmentUpdateRequest::translatedText));
-
-    segments.forEach(
-        segment -> segment.updateTranslatedText(translatedTextBySegmentId.get(segment.getId())));
+    return segments.stream()
+        .map(
+            segment ->
+                new ProjectResultSegmentResponse(
+                    segment.getId(),
+                    segment.getTranslatedText(),
+                    translatedWordsBySegmentId.getOrDefault(segment.getId(), List.of())))
+        .toList();
   }
 
   private void validateSegments(List<Segment> segments, List<Long> segmentIds, Long projectId) {

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -174,14 +174,9 @@ public class ProjectService {
     List<Segment> segments = segmentRepository.findByIdIn(segmentIds);
 
     validateSegments(segments, segmentIds, projectId);
-    savedWordRepository.deleteBySegmentIdsAndWordType(segmentIds, SegmentWordType.TRANSLATION);
-
-    segmentWordRepository.deleteBySegmentIdInAndWordType(segmentIds, SegmentWordType.TRANSLATION);
     updateTranslatedTexts(segments, request.segments());
-    List<SegmentWord> newTranslatedWords = createTranslationSegmentWords(segments);
 
-    List<SegmentWord> savedTranslatedWords = segmentWordRepository.saveAll(newTranslatedWords);
-
+    List<SegmentWord> savedTranslatedWords = recreateTranslatedSegmentWords(segmentIds, segments);
     List<ProjectResultSegmentResponse> segmentResponses =
         createProjectResultSegmentResponses(segments, savedTranslatedWords);
 
@@ -227,6 +222,16 @@ public class ProjectService {
                     segment.getTranslatedText(),
                     translatedWordsBySegmentId.getOrDefault(segment.getId(), List.of())))
         .toList();
+  }
+
+  private List<SegmentWord> recreateTranslatedSegmentWords(
+      List<Long> segmentIds, List<Segment> segments) {
+    savedWordRepository.deleteBySegmentIdsAndWordType(segmentIds, SegmentWordType.TRANSLATION);
+    segmentWordRepository.deleteBySegmentIdInAndWordType(segmentIds, SegmentWordType.TRANSLATION);
+
+    List<SegmentWord> newTranslatedWords = createTranslationSegmentWords(segments);
+
+    return segmentWordRepository.saveAll(newTranslatedWords);
   }
 
   private void validateSegments(List<Segment> segments, List<Long> segmentIds, Long projectId) {

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -97,10 +97,7 @@ public class ProjectService {
 
   @Transactional(readOnly = true)
   public ProjectDetailResponse getProject(Long memberId, Long projectId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     return new ProjectDetailResponse(
         project.getId(),
@@ -115,10 +112,7 @@ public class ProjectService {
 
   @Transactional(readOnly = true)
   public String getVideoPresignedUrl(Long memberId, Long projectId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     if (project.getFileKey() == null || project.getFileKey().isBlank()) {
       throw new IllegalArgumentException("업로드된 영상이 없습니다.");
@@ -130,10 +124,7 @@ public class ProjectService {
   public ProjectUpdateResponse updateProject(
       Long memberId, Long projectId, ProjectUpdateRequest request) {
 
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     project.updateTitle(request.title());
 
@@ -141,10 +132,7 @@ public class ProjectService {
   }
 
   public ProjectDeleteResponse deleteProject(Long memberId, Long projectId) {
-    Project project =
-        projectRepository
-            .findByIdAndMemberId(projectId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
+    Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     List<Job> jobs = jobRepository.findByProjectId(projectId);
 

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -134,6 +134,17 @@ public class ProjectService {
   public ProjectDeleteResponse deleteProject(Long memberId, Long projectId) {
     Project project = findProjectByIdAndMemberId(projectId, memberId);
 
+    deleteProjectRelatedData(projectId);
+
+    if (project.getSourceType() == SourceType.UPLOAD) {
+      s3UploadService.deleteFile(project.getFileKey());
+    }
+    projectRepository.delete(project);
+
+    return new ProjectDeleteResponse(projectId, true);
+  }
+
+  private void deleteProjectRelatedData(Long projectId) {
     List<Job> jobs = jobRepository.findByProjectId(projectId);
 
     savedWordRepository.deleteByProjectId(projectId);
@@ -148,12 +159,6 @@ public class ProjectService {
     }
 
     jobRepository.deleteByProjectId(projectId);
-    if (project.getSourceType() == SourceType.UPLOAD) {
-      s3UploadService.deleteFile(project.getFileKey());
-    }
-    projectRepository.delete(project);
-
-    return new ProjectDeleteResponse(projectId, true);
   }
 
   @Transactional

--- a/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
@@ -26,19 +26,11 @@ public class SavedWordService {
 
   @Transactional
   public SavedWordResponse createSavedWord(Long memberId, SavedWordCreateRequest request) {
-    if (request.segmentWordId() == null) {
-      throw new IllegalArgumentException("segmentWordId는 필수입니다.");
-    }
-    if (request.word() == null || request.word().isBlank()) {
-      throw new IllegalArgumentException("word는 필수입니다.");
-    }
+    validateSavedWordCreateRequest(request);
+    validateDuplicateSavedWord(memberId, request.segmentWordId());
 
     Member member = findMemberById(memberId);
     SegmentWord segmentWord = findSegmentWordById(request.segmentWordId());
-
-    if (savedWordRepository.existsByMemberIdAndSegmentWordId(memberId, request.segmentWordId())) {
-      throw new IllegalArgumentException("이미 저장한 단어입니다.");
-    }
 
     SavedWord savedWord =
         new SavedWord(
@@ -51,6 +43,22 @@ public class SavedWordService {
             request.matchedExpression());
 
     return SavedWordResponse.from(savedWordRepository.save(savedWord));
+  }
+
+  private void validateSavedWordCreateRequest(SavedWordCreateRequest request) {
+    if (request.segmentWordId() == null) {
+      throw new IllegalArgumentException("segmentWordId는 필수입니다.");
+    }
+
+    if (request.word() == null || request.word().isBlank()) {
+      throw new IllegalArgumentException("word는 필수입니다.");
+    }
+  }
+
+  private void validateDuplicateSavedWord(Long memberId, Long segmentWordId) {
+    if (savedWordRepository.existsByMemberIdAndSegmentWordId(memberId, segmentWordId)) {
+      throw new IllegalArgumentException("이미 저장한 단어입니다.");
+    }
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
@@ -33,15 +33,8 @@ public class SavedWordService {
       throw new IllegalArgumentException("word는 필수입니다.");
     }
 
-    Member member =
-        memberRepository
-            .findById(memberId)
-            .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
-
-    SegmentWord segmentWord =
-        segmentWordRepository
-            .findById(request.segmentWordId())
-            .orElseThrow(() -> new IllegalArgumentException("세그먼트 단어를 찾을 수 없습니다."));
+    Member member = findMemberById(memberId);
+    SegmentWord segmentWord = findSegmentWordById(request.segmentWordId());
 
     if (savedWordRepository.existsByMemberIdAndSegmentWordId(memberId, request.segmentWordId())) {
       throw new IllegalArgumentException("이미 저장한 단어입니다.");
@@ -69,21 +62,32 @@ public class SavedWordService {
 
   @Transactional
   public void deleteSavedWord(Long memberId, Long savedWordId) {
-    SavedWord savedWord =
-        savedWordRepository
-            .findByIdAndMemberId(savedWordId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
-
+    SavedWord savedWord = findSavedWordByIdAndMemberId(savedWordId, memberId);
     savedWordRepository.delete(savedWord);
   }
 
   @Transactional(readOnly = true)
   public SavedWordExampleResponse generateExamples(Long memberId, Long savedWordId) {
-    SavedWord savedWord =
-        savedWordRepository
-            .findByIdAndMemberId(savedWordId, memberId)
-            .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
+    SavedWord savedWord = findSavedWordByIdAndMemberId(savedWordId, memberId);
 
     return wordsExplainService.generateExamples(savedWord);
+  }
+
+  private Member findMemberById(Long memberId) {
+    return memberRepository
+        .findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+  }
+
+  private SegmentWord findSegmentWordById(Long segmentWordId) {
+    return segmentWordRepository
+        .findById(segmentWordId)
+        .orElseThrow(() -> new IllegalArgumentException("세그먼트 단어를 찾을 수 없습니다."));
+  }
+
+  private SavedWord findSavedWordByIdAndMemberId(Long savedWordId, Long memberId) {
+    return savedWordRepository
+        .findByIdAndMemberId(savedWordId, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
   }
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -52,16 +52,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     }
 
     String prompt = createPrompt(request);
-
-    Map<String, Object> body =
-        Map.of(
-            "model", model,
-            "input", prompt,
-            "store", false);
-
-    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
-
-    String outputText = extractOutputText(response);
+    String outputText = callOpenAi(prompt);
 
     try {
       WordExplainAiResult result = objectMapper.readValue(outputText, WordExplainAiResult.class);
@@ -110,6 +101,18 @@ public class WordsExplainServiceImpl implements WordsExplainService {
             getSelectedTextLanguage(request),
             request.targetLanguage(),
             getRelatedWordsLanguage(request));
+  }
+
+  private String callOpenAi(String prompt) {
+    Map<String, Object> body =
+        Map.of(
+            "model", model,
+            "input", prompt,
+            "store", false);
+
+    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
+
+    return extractOutputText(response);
   }
 
   @SuppressWarnings("unchecked")
@@ -205,15 +208,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
             """
             .formatted(expression, targetLanguage);
 
-    Map<String, Object> body =
-        Map.of(
-            "model", model,
-            "input", prompt,
-            "store", false);
-
-    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
-
-    String outputText = extractOutputText(response);
+    String outputText = callOpenAi(prompt);
 
     try {
       RelatedWordsResult result = objectMapper.readValue(outputText, RelatedWordsResult.class);
@@ -237,15 +232,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
 
     String prompt = createExamplePrompt(savedWord);
 
-    Map<String, Object> body =
-        Map.of(
-            "model", model,
-            "input", prompt,
-            "store", false);
-
-    Map response = openAiRestClient.post().uri("/responses").body(body).retrieve().body(Map.class);
-
-    String outputText = extractOutputText(response);
+    String outputText = callOpenAi(prompt);
 
     try {
       ExampleResult result = objectMapper.readValue(outputText, ExampleResult.class);

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -54,15 +54,10 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     String prompt = createPrompt(request);
     String outputText = callOpenAi(prompt);
 
-    try {
-      WordExplainAiResult result = objectMapper.readValue(outputText, WordExplainAiResult.class);
+    WordExplainAiResult result =
+        parseOpenAiResponse(outputText, WordExplainAiResult.class, "OpenAI 응답 파싱에 실패했습니다.");
 
-      return new WordsExplainResponse(
-          request.word(), result.meaning(), result.relatedWords(), false);
-
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("OpenAI 응답 파싱에 실패했습니다.", e);
-    }
+    return new WordsExplainResponse(request.word(), result.meaning(), result.relatedWords(), false);
   }
 
   private String createPrompt(WordsExplainRequest request) {
@@ -121,6 +116,14 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     Map<String, Object> message = output.get(0);
     List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
     return (String) content.get(0).get("text");
+  }
+
+  private <T> T parseOpenAiResponse(String outputText, Class<T> resultType, String errorMessage) {
+    try {
+      return objectMapper.readValue(outputText, resultType);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(errorMessage, e);
+    }
   }
 
   private record WordExplainAiResult(String meaning, List<String> relatedWords) {}
@@ -233,16 +236,10 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     String prompt = createExamplePrompt(savedWord);
 
     String outputText = callOpenAi(prompt);
+    ExampleResult result =
+        parseOpenAiResponse(outputText, ExampleResult.class, "OpenAI 예문 응답 파싱에 실패했습니다.");
 
-    try {
-      ExampleResult result = objectMapper.readValue(outputText, ExampleResult.class);
-
-      return new SavedWordExampleResponse(
-          savedWord.getId(), savedWord.getWord(), result.examples());
-
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("OpenAI 예문 응답 파싱에 실패했습니다.", e);
-    }
+    return new SavedWordExampleResponse(savedWord.getId(), savedWord.getWord(), result.examples());
   }
 
   private String createExamplePrompt(SavedWord savedWord) {


### PR DESCRIPTION
## 작업 개요
서비스 계층 리팩토링 및 중복 코드 제거

## 관련 이슈
- close #160 

## 작업 내용
- SavedWordService 검증 및 조회 로직 분리
- MemberService 조회 로직 분리
- MemberWithdrawService 회원 조회 로직 분리
- LearningContentService 응답 생성 로직 분리
- ResultCopyService 엔티티 생성 로직 분리
- WordsExplainService OpenAI 호출 및 응답 파싱 로직 공통화
- JobResultService 결과 저장 로직 분리
- OCR 생성 로직을 OcrItemFactory로 분리

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 기능 변경 없이 서비스 계층 구조 개선 및 중복 코드 제거 진행