### PR TITLE
refactor: SavedWordRepository 및 Tokenizer 구조 정리

### DIFF
--- a/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/repository/SavedWordRepository.java
@@ -20,10 +20,9 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
   @Modifying
   @Query(
       """
-
-                  DELETE FROM SavedWord sw
-    WHERE sw.segmentWord.segment.job.project.id = :projectId
-    """)
+          DELETE FROM SavedWord sw
+          WHERE sw.segmentWord.segment.job.project.id = :projectId
+          """)
   void deleteByProjectId(@Param("projectId") Long projectId);
 
   @Modifying
@@ -48,12 +47,11 @@ public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
           """)
   void deleteByJobId(@Param("jobId") Long jobId);
 
-  Optional<SavedWord> findByIdAndMember_Id(Long id, Long memberId);
-
   @Modifying
-  @Query("""
-    DELETE FROM SavedWord sw
-    WHERE sw.member.id = :memberId
-    """)
+  @Query(
+      """
+          DELETE FROM SavedWord sw
+          WHERE sw.member.id = :memberId
+          """)
   void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
+++ b/backend/src/main/java/com/overlang/domain/segment/repository/SegmentWordRepository.java
@@ -7,15 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 
 public interface SegmentWordRepository extends JpaRepository<SegmentWord, Long> {
-  List<SegmentWord> findBySegmentIdOrderBySeqAsc(Long segmentId);
 
   void deleteBySegmentJobId(Long jobId);
 
   List<SegmentWord> findBySegmentIdIn(List<Long> segmentIds);
-
-  List<SegmentWord> findBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
-
-  void deleteBySegmentIdAndWordType(Long segmentId, SegmentWordType wordType);
 
   @Modifying
   void deleteBySegmentIdInAndWordType(List<Long> segmentIds, SegmentWordType wordType);

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/ChineseSegmentWordTokenizer.java
@@ -17,14 +17,10 @@ public class ChineseSegmentWordTokenizer implements SegmentWordTokenizer {
 
   @Override
   public List<String> tokenize(String text) {
-    if (text == null || text.isBlank()) {
+    if (isBlank(text)) {
       return List.of();
     }
 
     return segmenter.sentenceProcess(text).stream().filter(this::isValidWord).toList();
-  }
-
-  private boolean isValidWord(String word) {
-    return word != null && !word.isBlank();
   }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/JapaneseSegmentWordTokenizer.java
@@ -18,7 +18,7 @@ public class JapaneseSegmentWordTokenizer implements SegmentWordTokenizer {
 
   @Override
   public List<String> tokenize(String text) {
-    if (text == null || text.isBlank()) {
+    if (isBlank(text)) {
       return List.of();
     }
 
@@ -26,9 +26,5 @@ public class JapaneseSegmentWordTokenizer implements SegmentWordTokenizer {
         .map(Token::getSurface)
         .filter(this::isValidWord)
         .toList();
-  }
-
-  private boolean isValidWord(String word) {
-    return word != null && !word.isBlank();
   }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/SegmentWordTokenizer.java
@@ -8,4 +8,12 @@ public interface SegmentWordTokenizer {
   boolean supports(LanguageCode languageCode);
 
   List<String> tokenize(String text);
+
+  default boolean isBlank(String text) {
+    return text == null || text.isBlank();
+  }
+
+  default boolean isValidWord(String word) {
+    return word != null && !word.isBlank();
+  }
 }

--- a/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
+++ b/backend/src/main/java/com/overlang/domain/segment/tokenizer/WhitespaceSegmentWordTokenizer.java
@@ -19,14 +19,10 @@ public class WhitespaceSegmentWordTokenizer implements SegmentWordTokenizer {
 
   @Override
   public List<String> tokenize(String text) {
-    if (text == null || text.isBlank()) {
+    if (isBlank(text)) {
       return List.of();
     }
 
     return Arrays.stream(text.trim().split(WORD_SPLIT_REGEX)).filter(this::isValidWord).toList();
-  }
-
-  private boolean isValidWord(String word) {
-    return word != null && !word.isBlank();
   }
 }


### PR DESCRIPTION
## 작업 개요
SavedWordRepository 및 Tokenizer 계층 리팩토링

## 관련 이슈
- close #165 

## 작업 내용
- SavedWordRepository 중복 조회 메서드 제거
- SavedWordRepository 쿼리 포맷 정리
- SegmentWordTokenizer 공통 검증 로직 추가
- Chinese/Japanese/Whitespace Tokenizer 중복 코드 제거
- SegmentWordRepository 미사용 메서드 제거

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- 기능 변경 없이 Repository 및 Tokenizer 계층의 중복 코드를 제거하고 가독성을 개선