### PR TITLE
refactor: 예외 처리 구조 개선

### DIFF
--- a/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobResultService.java
@@ -19,6 +19,7 @@ import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
 import com.overlang.domain.segment.tokenizer.SegmentWordTokenizerProvider;
+import com.overlang.global.exception.job.JobNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class JobResultService {
 
   private void validateJobOwner(Long jobId, Long memberId) {
     if (!jobRepository.existsByIdAndProjectMemberId(jobId, memberId)) {
-      throw new IllegalArgumentException("작업을 찾을 수 없습니다.");
+      throw new JobNotFoundException();
     }
   }
 

--- a/backend/src/main/java/com/overlang/domain/job/service/JobService.java
+++ b/backend/src/main/java/com/overlang/domain/job/service/JobService.java
@@ -13,6 +13,8 @@ import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.entity.ProjectStatus;
 import com.overlang.domain.project.repository.ProjectRepository;
+import com.overlang.global.exception.job.JobNotFoundException;
+import com.overlang.global.exception.project.ProjectNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -173,13 +175,13 @@ public class JobService {
   private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {
     return projectRepository
         .findByIdAndMemberId(projectId, memberId)
-        .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+        .orElseThrow(ProjectNotFoundException::new);
   }
 
   private Job findJobByIdAndMemberId(Long jobId, Long memberId) {
     return jobRepository
         .findByIdAndProjectMemberId(jobId, memberId)
-        .orElseThrow(() -> new IllegalArgumentException("작업을 찾을 수 없습니다."));
+        .orElseThrow(JobNotFoundException::new);
   }
 
   private Job findLatestJobByProjectId(Long projectId) {

--- a/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
+++ b/backend/src/main/java/com/overlang/domain/learning/service/LearningContentService.java
@@ -6,6 +6,7 @@ import com.overlang.domain.job.repository.JobRepository;
 import com.overlang.domain.learning.entity.LearningContent;
 import com.overlang.domain.learning.entity.LearningContentType;
 import com.overlang.domain.learning.repository.LearningContentRepository;
+import com.overlang.global.exception.job.JobNotFoundException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class LearningContentService {
 
   private void validateJobOwner(Long jobId, Long memberId) {
     if (!jobRepository.existsByIdAndProjectMemberId(jobId, memberId)) {
-      throw new IllegalArgumentException("작업을 찾을 수 없습니다.");
+      throw new JobNotFoundException();
     }
   }
 }

--- a/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
+++ b/backend/src/main/java/com/overlang/domain/member/service/MemberWithdrawService.java
@@ -9,6 +9,7 @@ import com.overlang.domain.project.entity.Project;
 import com.overlang.domain.project.repository.ProjectRepository;
 import com.overlang.domain.project.service.ProjectService;
 import com.overlang.domain.savedword.repository.SavedWordRepository;
+import com.overlang.global.exception.member.MemberNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,9 +38,7 @@ public class MemberWithdrawService {
   }
 
   private Member findMemberById(Long memberId) {
-    return memberRepository
-        .findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
   }
 
   private void deleteMemberProjects(Long memberId) {

--- a/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/overlang/domain/project/service/ProjectService.java
@@ -17,6 +17,11 @@ import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.entity.SegmentWordType;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
+import com.overlang.global.exception.member.MemberNotFoundException;
+import com.overlang.global.exception.project.InvalidProjectSegmentException;
+import com.overlang.global.exception.project.ProjectNotFoundException;
+import com.overlang.global.exception.project.ProjectVideoNotFoundException;
+import com.overlang.global.exception.segment.SegmentNotFoundException;
 import com.overlang.global.util.YoutubeUrlUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,10 +49,7 @@ public class ProjectService {
   private final LearningContentRepository learningContentRepository;
 
   public ProjectCreateResponse createProject(Long memberId, ProjectCreateRequest request) {
-    Member member =
-        memberRepository
-            .findById(memberId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
     Project savedProject = projectRepository.save(createProjectEntity(member, request));
 
@@ -118,7 +120,7 @@ public class ProjectService {
     Project project = findProjectByIdAndMemberId(projectId, memberId);
 
     if (project.getFileKey() == null || project.getFileKey().isBlank()) {
-      throw new IllegalArgumentException("업로드된 영상이 없습니다.");
+      throw new ProjectVideoNotFoundException();
     }
 
     return s3UploadService.generatePresignedGetUrl(project.getFileKey());
@@ -236,7 +238,7 @@ public class ProjectService {
 
   private void validateSegments(List<Segment> segments, List<Long> segmentIds, Long projectId) {
     if (segments.size() != segmentIds.size()) {
-      throw new IllegalArgumentException("존재하지 않는 segment가 포함되어 있습니다.");
+      throw new SegmentNotFoundException();
     }
 
     boolean hasInvalidSegment =
@@ -244,14 +246,14 @@ public class ProjectService {
             .anyMatch(segment -> !segment.getJob().getProject().getId().equals(projectId));
 
     if (hasInvalidSegment) {
-      throw new IllegalArgumentException("다른 프로젝트의 segment는 수정할 수 없습니다.");
+      throw new InvalidProjectSegmentException();
     }
   }
 
   private Project findProjectByIdAndMemberId(Long projectId, Long memberId) {
     return projectRepository
         .findByIdAndMemberId(projectId, memberId)
-        .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+        .orElseThrow(ProjectNotFoundException::new);
   }
 
   private List<SegmentWord> createTranslationSegmentWords(List<Segment> segments) {

--- a/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
+++ b/backend/src/main/java/com/overlang/domain/savedword/service/SavedWordService.java
@@ -10,6 +10,10 @@ import com.overlang.domain.savedword.repository.SavedWordRepository;
 import com.overlang.domain.segment.entity.SegmentWord;
 import com.overlang.domain.segment.repository.SegmentWordRepository;
 import com.overlang.domain.word.service.WordsExplainService;
+import com.overlang.global.exception.member.MemberNotFoundException;
+import com.overlang.global.exception.savedword.DuplicateSavedWordException;
+import com.overlang.global.exception.savedword.SavedWordNotFoundException;
+import com.overlang.global.exception.segment.SegmentWordNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,7 +61,7 @@ public class SavedWordService {
 
   private void validateDuplicateSavedWord(Long memberId, Long segmentWordId) {
     if (savedWordRepository.existsByMemberIdAndSegmentWordId(memberId, segmentWordId)) {
-      throw new IllegalArgumentException("이미 저장한 단어입니다.");
+      throw new DuplicateSavedWordException();
     }
   }
 
@@ -82,20 +86,18 @@ public class SavedWordService {
   }
 
   private Member findMemberById(Long memberId) {
-    return memberRepository
-        .findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+    return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
   }
 
   private SegmentWord findSegmentWordById(Long segmentWordId) {
     return segmentWordRepository
         .findById(segmentWordId)
-        .orElseThrow(() -> new IllegalArgumentException("세그먼트 단어를 찾을 수 없습니다."));
+        .orElseThrow(SegmentWordNotFoundException::new);
   }
 
   private SavedWord findSavedWordByIdAndMemberId(Long savedWordId, Long memberId) {
     return savedWordRepository
         .findByIdAndMemberId(savedWordId, memberId)
-        .orElseThrow(() -> new IllegalArgumentException("저장 단어를 찾을 수 없습니다."));
+        .orElseThrow(SavedWordNotFoundException::new);
   }
 }

--- a/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
+++ b/backend/src/main/java/com/overlang/domain/word/service/WordsExplainServiceImpl.java
@@ -13,6 +13,8 @@ import com.overlang.domain.savedword.entity.SavedWord;
 import com.overlang.domain.segment.entity.Segment;
 import com.overlang.domain.segment.repository.SegmentRepository;
 import com.overlang.domain.segment.tokenizer.SegmentWordTokenizerProvider;
+import com.overlang.global.exception.external.OpenAiResponseParseException;
+import com.overlang.global.exception.segment.SegmentNotFoundException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +124,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
     try {
       return objectMapper.readValue(outputText, resultType);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException(errorMessage, e);
+      throw new OpenAiResponseParseException();
     }
   }
 
@@ -132,9 +134,7 @@ public class WordsExplainServiceImpl implements WordsExplainService {
 
   private Optional<LearningContent> findMatchedExpression(WordsExplainRequest request) {
     Segment segment =
-        segmentRepository
-            .findById(request.segmentId())
-            .orElseThrow(() -> new IllegalArgumentException("세그먼트를 찾을 수 없습니다."));
+        segmentRepository.findById(request.segmentId()).orElseThrow(SegmentNotFoundException::new);
 
     String clickedWord = normalize(request.word());
 

--- a/backend/src/main/java/com/overlang/global/advice/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/overlang/global/advice/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.overlang.global.advice;
 
 import com.overlang.global.auth.UnauthorizedException;
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
 import com.overlang.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,14 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException e) {
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
         .body(ApiResponse.error("AUTH_001", e.getMessage()));
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+    ErrorCode errorCode = e.getErrorCode();
+
+    return ResponseEntity.status(errorCode.getHttpStatus())
+        .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
   }
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/java/com/overlang/global/config/S3Config.java
+++ b/backend/src/main/java/com/overlang/global/config/S3Config.java
@@ -21,23 +21,23 @@ public class S3Config {
   @Value("${cloud.aws.region.static}")
   private String region;
 
+  private AwsBasicCredentials awsCredentials() {
+    return AwsBasicCredentials.create(accessKey, secretKey);
+  }
+
   @Bean
   public S3Client s3Client() {
-    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
     return S3Client.builder()
         .region(Region.of(region))
-        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials()))
         .build();
   }
 
   @Bean
   public S3Presigner s3Presigner() {
-    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
     return S3Presigner.builder()
         .region(Region.of(region))
-        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials()))
         .build();
   }
 }

--- a/backend/src/main/java/com/overlang/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/overlang/global/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.overlang.global.exception;
+
+public class BusinessException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/overlang/global/exception/ErrorCode.java
@@ -1,0 +1,64 @@
+package com.overlang.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+  // Common
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "요청한 대상을 찾을 수 없습니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다."),
+
+  // Auth
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+
+  // Member
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "존재하지 않는 회원입니다."),
+
+  // Project
+  PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_404", "존재하지 않는 프로젝트입니다."),
+  PROJECT_VIDEO_NOT_FOUND(HttpStatus.BAD_REQUEST, "PROJECT_400", "업로드된 영상이 없습니다."),
+  INVALID_PROJECT_SEGMENT(HttpStatus.BAD_REQUEST, "PROJECT_400", "해당 프로젝트의 세그먼트만 수정할 수 있습니다."),
+
+  // Job
+  JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "JOB_404", "작업을 찾을 수 없습니다."),
+  INVALID_JOB_REQUEST(HttpStatus.BAD_REQUEST, "JOB_400", "잘못된 작업 요청입니다."),
+
+  // SavedWord
+  SAVED_WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "SAVED_WORD_404", "저장 단어를 찾을 수 없습니다."),
+  DUPLICATE_SAVED_WORD(HttpStatus.CONFLICT, "SAVED_WORD_409", "이미 저장된 단어입니다."),
+
+  // Segment
+  SEGMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SEGMENT_404", "세그먼트를 찾을 수 없습니다."),
+  SEGMENT_WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "SEGMENT_WORD_404", "세그먼트 단어를 찾을 수 없습니다."),
+
+  // File
+  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500", "파일 업로드에 실패했습니다."),
+  INVALID_FILE_REQUEST(HttpStatus.BAD_REQUEST, "FILE_400", "잘못된 파일 요청입니다."),
+
+  // External
+  OPENAI_RESPONSE_PARSE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI_500", "OpenAI 응답 처리 중 오류가 발생했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  ErrorCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/external/OpenAiResponseParseException.java
+++ b/backend/src/main/java/com/overlang/global/exception/external/OpenAiResponseParseException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.external;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class OpenAiResponseParseException extends BusinessException {
+
+  public OpenAiResponseParseException() {
+    super(ErrorCode.OPENAI_RESPONSE_PARSE_FAILED);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/job/JobNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/job/JobNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.job;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class JobNotFoundException extends BusinessException {
+
+  public JobNotFoundException() {
+    super(ErrorCode.JOB_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/member/MemberNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/member/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.member;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class MemberNotFoundException extends BusinessException {
+
+  public MemberNotFoundException() {
+    super(ErrorCode.MEMBER_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/project/InvalidProjectSegmentException.java
+++ b/backend/src/main/java/com/overlang/global/exception/project/InvalidProjectSegmentException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.project;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class InvalidProjectSegmentException extends BusinessException {
+
+  public InvalidProjectSegmentException() {
+    super(ErrorCode.INVALID_PROJECT_SEGMENT);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/project/ProjectNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/project/ProjectNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.project;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class ProjectNotFoundException extends BusinessException {
+
+  public ProjectNotFoundException() {
+    super(ErrorCode.PROJECT_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/project/ProjectVideoNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/project/ProjectVideoNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.project;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class ProjectVideoNotFoundException extends BusinessException {
+
+  public ProjectVideoNotFoundException() {
+    super(ErrorCode.PROJECT_VIDEO_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/savedword/DuplicateSavedWordException.java
+++ b/backend/src/main/java/com/overlang/global/exception/savedword/DuplicateSavedWordException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.savedword;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class DuplicateSavedWordException extends BusinessException {
+
+  public DuplicateSavedWordException() {
+    super(ErrorCode.DUPLICATE_SAVED_WORD);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/savedword/SavedWordNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/savedword/SavedWordNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.savedword;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class SavedWordNotFoundException extends BusinessException {
+
+  public SavedWordNotFoundException() {
+    super(ErrorCode.SAVED_WORD_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/segment/SegmentNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/segment/SegmentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.segment;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class SegmentNotFoundException extends BusinessException {
+
+  public SegmentNotFoundException() {
+    super(ErrorCode.SEGMENT_NOT_FOUND);
+  }
+}

--- a/backend/src/main/java/com/overlang/global/exception/segment/SegmentWordNotFoundException.java
+++ b/backend/src/main/java/com/overlang/global/exception/segment/SegmentWordNotFoundException.java
@@ -1,0 +1,11 @@
+package com.overlang.global.exception.segment;
+
+import com.overlang.global.exception.BusinessException;
+import com.overlang.global.exception.ErrorCode;
+
+public class SegmentWordNotFoundException extends BusinessException {
+
+  public SegmentWordNotFoundException() {
+    super(ErrorCode.SEGMENT_WORD_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
## 작업 개요
기존 `IllegalArgumentException` 중심의 예외 처리 방식 개선, ErrorCode 및 Custom Exception 기반의 예외 처리 구조 도입하여 예외 응답의 일관성과 유지보수성 향상

## 관련 이슈
- close #164

## 작업 내용
- ErrorCode 및 BusinessException 기반 예외 처리 구조 추가
- GlobalExceptionHandler와 Custom Exception 연동
- Member, Project, Job, SavedWord, Segment 도메인 예외 분리
- DuplicateSavedWordException 추가
- ProjectVideoNotFoundException 추가
- InvalidProjectSegmentException 추가
- OpenAiResponseParseException 추가
- 기존 IllegalArgumentException 일부를 Custom Exception으로 교체
- RuntimeException 사용 구간 확인

## 체크리스트 (DoD)
- [x] 빌드 및 테스트 통과 확인
- [x] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [x] Self-Review 완료

## 기타 사항
- 예외 응답 구조는 기존과 동일하게 유지
- 일부 error.code가 세분화되었으나 FE 영향 없음