### PR TITLE
Be/fix webconfig

### DIFF
--- a/backend/src/main/java/com/overlang/global/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/overlang/global/config/FirebaseConfig.java
@@ -4,8 +4,10 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +15,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
-// firebase 인증 사용을 위한 서버 초기화 설정
 @Slf4j
 @Configuration
 public class FirebaseConfig {
@@ -21,33 +22,38 @@ public class FirebaseConfig {
   @Value("${firebase.service-account-path:}")
   private String keyPath;
 
+  @Value("${firebase.service-account-json:}")
+  private String serviceAccountJson;
+
   @PostConstruct
   public void init() {
-    if (keyPath == null || keyPath.isBlank()) {
-      log.warn("Firebase disabled: FIREBASE_SERVICE_ACCOUNT_PATH is empty");
-      return;
-    }
-
     if (!FirebaseApp.getApps().isEmpty()) {
       log.info("Firebase already initialized");
       return;
     }
 
-    try (InputStream in = getServiceAccountStream(keyPath)) {
-
+    try (InputStream in = getServiceAccountStream()) {
       FirebaseOptions options =
           FirebaseOptions.builder().setCredentials(GoogleCredentials.fromStream(in)).build();
 
       FirebaseApp.initializeApp(options);
-      log.info("Firebase Admin initialized successfully (path: {})", keyPath);
+      log.info("Firebase Admin initialized successfully");
 
     } catch (Exception e) {
       log.error("Firebase initialization failed", e);
     }
   }
 
-  private InputStream getServiceAccountStream(String path) throws Exception {
-    String trimmed = (path == null) ? "" : path.trim();
+  private InputStream getServiceAccountStream() throws Exception {
+    if (serviceAccountJson != null && !serviceAccountJson.isBlank()) {
+      return new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8));
+    }
+
+    String trimmed = (keyPath == null) ? "" : keyPath.trim();
+
+    if (trimmed.isBlank()) {
+      throw new IllegalStateException("Firebase service account is not configured");
+    }
 
     if (trimmed.startsWith("classpath:")) {
       String cp = trimmed.substring("classpath:".length());

--- a/backend/src/main/java/com/overlang/global/config/WebConfig.java
+++ b/backend/src/main/java/com/overlang/global/config/WebConfig.java
@@ -17,7 +17,8 @@ public class WebConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry registry) {
     registry
         .addMapping("/**") // 모든 API 경로에 대해
-        .allowedOrigins("http://localhost:5173") // 프론트엔드 개발 서버 주소
+        .allowedOrigins(
+            "http://localhost:5173", "https://overlang-production.up.railway.app") // 프론트엔드 개발 서버 주소
         .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
         .allowedHeaders("*")
         .allowCredentials(true)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,6 +30,7 @@ spring.servlet.multipart.max-request-size=2GB
 # Redis
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:ASiqAMdIQKOOkpuhVFWfrcNuSMmtfLOl}
 
 worker.secret=${WORKER_SECRET:overlang-worker-secret}
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.password=${DB_PASSWORD:overlang1234}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 firebase.service-account-path=${FIREBASE_SERVICE_ACCOUNT_PATH:classpath:overlang-firebase-admin.json}
-
+firebase.service-account-json=${FIREBASE_SERVICE_ACCOUNT_JSON:}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true


### PR DESCRIPTION
## 작업 개요
Redis 비밀번호 환경변수 설정을 추가하여 Railway Redis 인증을 지원

## 관련 이슈
- close #

## 작업 내용
- `spring.data.redis.password` 설정 추가
- `REDIS_PASSWORD` 환경변수 연동

## 체크리스트 (DoD)
- [ ] 빌드 및 테스트 통과 확인
- [ ] (BE만) `./gradlew spotlessApply` 실행 완료
- [ ] 관련 API 문서(Swagger 등) 업데이트 완료
- [ ] Self-Review 완료

## UI 스크린샷 (해당 시)

## 기타 사항
- Railway Redis 사용 시 `REDIS_PASSWORD` 환경변수 설정 필요